### PR TITLE
fix(security): sanitize refund errors in webhook payloads

### DIFF
--- a/products/stablecoin-gateway/apps/api/src/services/refund.service.ts
+++ b/products/stablecoin-gateway/apps/api/src/services/refund.service.ts
@@ -27,6 +27,7 @@ import {
   CONFIRMATION_REQUIREMENTS,
 } from './blockchain-transaction.service.js';
 import { BlockchainMonitorService } from './blockchain-monitor.service.js';
+import { sanitizeErrorForWebhook } from '../utils/error-sanitizer.js';
 
 /**
  * Compute the total refunded amount from a list of refunds,
@@ -408,7 +409,7 @@ export class RefundService {
             reason: failedRefund.reason,
             status: failedRefund.status,
             created_at: failedRefund.createdAt.toISOString(),
-            error: result.error,
+            error: sanitizeErrorForWebhook(result.error),
           }
         );
 
@@ -485,7 +486,7 @@ export class RefundService {
           reason: failedRefund.reason,
           status: failedRefund.status,
           created_at: failedRefund.createdAt.toISOString(),
-          error: error instanceof Error ? error.message : 'Unknown error',
+          error: sanitizeErrorForWebhook(error instanceof Error ? error.message : 'Unknown error'),
         }
       );
 

--- a/products/stablecoin-gateway/apps/api/src/utils/error-sanitizer.ts
+++ b/products/stablecoin-gateway/apps/api/src/utils/error-sanitizer.ts
@@ -1,0 +1,54 @@
+/**
+ * Error Sanitizer
+ *
+ * Strips sensitive infrastructure details from error messages
+ * before they are sent to external parties via webhooks.
+ *
+ * Redacts:
+ * - URLs (http/https)
+ * - AWS ARNs
+ * - Database/Redis connection strings
+ * - IP:port patterns
+ */
+
+const SANITIZATION_RULES: Array<{ pattern: RegExp; replacement: string }> = [
+  // Connection strings (postgresql://, redis://, mysql://, etc.)
+  // Must come before generic URL pattern
+  {
+    pattern: /(?:postgresql|postgres|redis|mysql|mongodb|amqp):\/\/\S+/gi,
+    replacement: '[REDACTED_CONNECTION_STRING]',
+  },
+  // AWS ARNs
+  {
+    pattern: /arn:aws:[a-z0-9-]+:[a-z0-9-]*:\d*:[^\s,)]+/gi,
+    replacement: '[REDACTED_ARN]',
+  },
+  // HTTP/HTTPS URLs
+  {
+    pattern: /https?:\/\/\S+/gi,
+    replacement: '[REDACTED_URL]',
+  },
+  // IP:port patterns (e.g. 10.0.1.50:8545)
+  {
+    pattern: /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d{1,5}/g,
+    replacement: '[REDACTED_IP]',
+  },
+];
+
+/**
+ * Sanitize an error message for inclusion in webhook payloads.
+ *
+ * Strips URLs, ARNs, connection strings, and IP:port patterns
+ * that could leak internal infrastructure details to merchants.
+ */
+export function sanitizeErrorForWebhook(error: string | undefined | null): string {
+  if (error == null) {
+    return 'An error occurred';
+  }
+
+  let sanitized = error;
+  for (const rule of SANITIZATION_RULES) {
+    sanitized = sanitized.replace(rule.pattern, rule.replacement);
+  }
+  return sanitized;
+}

--- a/products/stablecoin-gateway/apps/api/tests/services/refund-error-sanitization.test.ts
+++ b/products/stablecoin-gateway/apps/api/tests/services/refund-error-sanitization.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Refund Error Sanitization Tests
+ *
+ * Verifies that error messages in webhook payloads are sanitized
+ * to prevent leaking sensitive infrastructure details like RPC URLs,
+ * AWS ARNs, database connection strings, and IP:port patterns.
+ */
+
+import { sanitizeErrorForWebhook } from '../../src/utils/error-sanitizer';
+
+describe('sanitizeErrorForWebhook', () => {
+  describe('URL stripping', () => {
+    it('should redact HTTPS URLs', () => {
+      const input = 'Failed to send to https://polygon-rpc.com/v1/abc123';
+      expect(sanitizeErrorForWebhook(input)).toBe(
+        'Failed to send to [REDACTED_URL]'
+      );
+    });
+
+    it('should redact HTTP URLs', () => {
+      const input = 'Connection refused: http://internal-node:8545/rpc';
+      expect(sanitizeErrorForWebhook(input)).toBe(
+        'Connection refused: [REDACTED_URL]'
+      );
+    });
+
+    it('should redact multiple URLs', () => {
+      const input = 'Tried https://rpc1.com and https://rpc2.com/path';
+      const result = sanitizeErrorForWebhook(input);
+      expect(result).not.toContain('rpc1.com');
+      expect(result).not.toContain('rpc2.com');
+    });
+  });
+
+  describe('AWS ARN stripping', () => {
+    it('should redact KMS ARNs', () => {
+      const input = 'KMS key not found: arn:aws:kms:us-east-1:123456789:key/abc-123';
+      expect(sanitizeErrorForWebhook(input)).toBe(
+        'KMS key not found: [REDACTED_ARN]'
+      );
+    });
+
+    it('should redact IAM ARNs', () => {
+      const input = 'Access denied for arn:aws:iam::123456789:role/prod-signer';
+      expect(sanitizeErrorForWebhook(input)).toBe(
+        'Access denied for [REDACTED_ARN]'
+      );
+    });
+  });
+
+  describe('Connection string stripping', () => {
+    it('should redact PostgreSQL connection strings', () => {
+      const input = 'DB error: postgresql://user:pass@db.internal:5432/gateway';
+      expect(sanitizeErrorForWebhook(input)).toBe(
+        'DB error: [REDACTED_CONNECTION_STRING]'
+      );
+    });
+
+    it('should redact Redis connection strings', () => {
+      const input = 'Redis timeout: redis://default:secret@redis.internal:6379';
+      expect(sanitizeErrorForWebhook(input)).toBe(
+        'Redis timeout: [REDACTED_CONNECTION_STRING]'
+      );
+    });
+  });
+
+  describe('IP:port stripping', () => {
+    it('should redact IPv4:port patterns', () => {
+      const input = 'Connection refused to 10.0.1.50:8545';
+      expect(sanitizeErrorForWebhook(input)).toBe(
+        'Connection refused to [REDACTED_IP]'
+      );
+    });
+
+    it('should redact multiple IP:port patterns', () => {
+      const input = 'Tried 192.168.1.1:3000 and 10.0.0.1:8080';
+      const result = sanitizeErrorForWebhook(input);
+      expect(result).not.toContain('192.168.1.1');
+      expect(result).not.toContain('10.0.0.1');
+    });
+  });
+
+  describe('Safe messages preserved', () => {
+    it('should preserve simple error messages', () => {
+      expect(sanitizeErrorForWebhook('Insufficient balance')).toBe(
+        'Insufficient balance'
+      );
+    });
+
+    it('should preserve refund-related messages', () => {
+      expect(sanitizeErrorForWebhook('Refund amount exceeds payment')).toBe(
+        'Refund amount exceeds payment'
+      );
+    });
+
+    it('should preserve unknown error message', () => {
+      expect(sanitizeErrorForWebhook('Unknown error')).toBe('Unknown error');
+    });
+
+    it('should handle empty string', () => {
+      expect(sanitizeErrorForWebhook('')).toBe('');
+    });
+
+    it('should handle undefined/null gracefully', () => {
+      expect(sanitizeErrorForWebhook(undefined as any)).toBe('An error occurred');
+      expect(sanitizeErrorForWebhook(null as any)).toBe('An error occurred');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- New `sanitizeErrorForWebhook()` utility strips sensitive infrastructure details from error messages
- Applied at both webhook payload locations in `refund.service.ts` (lines 411, 488)
- Strips: URLs, AWS ARNs, database/Redis connection strings, IP:port patterns
- Preserves safe messages like "Insufficient balance"

## Test plan
- [x] Strips HTTPS/HTTP URLs → `[REDACTED_URL]`
- [x] Strips AWS ARNs → `[REDACTED_ARN]`
- [x] Strips PostgreSQL/Redis connection strings → `[REDACTED_CONNECTION_STRING]`
- [x] Strips IP:port patterns → `[REDACTED_IP]`
- [x] Preserves safe error messages
- [x] Handles undefined/null input gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)