### PR TITLE
fix(security): persist audit logs to database

### DIFF
--- a/products/stablecoin-gateway/apps/api/prisma/migrations/20260131080000_add_audit_log_table/migration.sql
+++ b/products/stablecoin-gateway/apps/api/prisma/migrations/20260131080000_add_audit_log_table/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "audit_logs" (
+    "id" TEXT NOT NULL,
+    "actor" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "resource_type" TEXT NOT NULL,
+    "resource_id" TEXT NOT NULL,
+    "details" JSONB,
+    "ip" TEXT,
+    "user_agent" TEXT,
+    "timestamp" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "audit_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "audit_logs_actor_idx" ON "audit_logs"("actor");
+
+-- CreateIndex
+CREATE INDEX "audit_logs_action_idx" ON "audit_logs"("action");
+
+-- CreateIndex
+CREATE INDEX "audit_logs_resource_type_idx" ON "audit_logs"("resource_type");
+
+-- CreateIndex
+CREATE INDEX "audit_logs_timestamp_idx" ON "audit_logs"("timestamp");

--- a/products/stablecoin-gateway/apps/api/prisma/schema.prisma
+++ b/products/stablecoin-gateway/apps/api/prisma/schema.prisma
@@ -238,3 +238,29 @@ enum WebhookStatus {
   SUCCEEDED
   FAILED
 }
+
+// ==================== Audit Log ====================
+
+model AuditLog {
+  id           String   @id @default(cuid())
+
+  // Who performed the action
+  actor        String
+  action       String
+  resourceType String   @map("resource_type")
+  resourceId   String   @map("resource_id")
+
+  // Optional context
+  details      Json?
+  ip           String?
+  userAgent    String?  @map("user_agent")
+
+  // Timestamp
+  timestamp    DateTime @default(now())
+
+  @@index([actor])
+  @@index([action])
+  @@index([resourceType])
+  @@index([timestamp])
+  @@map("audit_logs")
+}


### PR DESCRIPTION
## Summary
- Add `AuditLog` Prisma model with indexes for actor, action, resourceType, timestamp
- Replace in-memory `entries[]` array with `prisma.auditLog.create()` / `findMany()`
- Audit entries now survive process restarts (compliance requirement)
- Fire-and-forget pattern preserved (write failures logged, never thrown)
- PII redaction still applied before persistence
- Updated all existing audit log tests to async database-backed API

## Test plan
- [x] `record()` persists to database (verified via query)
- [x] `query()` retrieves filtered results from database
- [x] Date range filters work
- [x] PII redaction applied before persistence
- [x] DB write failure doesn't throw (fire-and-forget preserved)
- [x] All 19 audit log tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)