### PR TITLE
feat(stablecoin): wire frontend to real backend API

### DIFF
--- a/notes/features/feature-stablecoin-real-api-integration.md
+++ b/notes/features/feature-stablecoin-real-api-integration.md
@@ -1,0 +1,22 @@
+# Feature: Wire StableFlow Frontend to Real Backend API
+
+## Branch
+`feature/stablecoin/real-api-integration`
+
+## Summary
+Eliminate mock mode by wiring the frontend to the real backend API.
+
+## Changes
+1. Extend `api-client.ts` with signup, API key CRUD, webhook CRUD
+2. Create `ProtectedRoute.tsx` auth guard component
+3. Create `Signup.tsx` page matching Login.tsx style
+4. Update `App.tsx` with signup route and ProtectedRoute wrapper
+5. Change `.env` default from mock=true to mock=false
+
+## Key Findings
+- Backend uses PATCH for webhook updates (confirmed in webhooks.ts)
+- TokenManager stores tokens in memory only (security design)
+- Backend signup returns: `{id, email, created_at, access_token, refresh_token}`
+- Backend API key create returns: `{id, name, key, key_prefix, permissions, last_used_at, created_at}`
+- Backend webhook create returns: `{id, url, events, enabled, description, created_at, updated_at, secret}`
+- Backend webhook rotate-secret returns: `{id, secret, rotatedAt}`

--- a/products/stablecoin-gateway/apps/web/.env.example
+++ b/products/stablecoin-gateway/apps/web/.env.example
@@ -1,6 +1,6 @@
 # API Configuration
 VITE_API_URL=http://localhost:5001
-VITE_USE_MOCK_API=true
+VITE_USE_MOCK_API=false
 
 # Mock Mode Configuration
 # Set to 'true' ONLY for local development/testing

--- a/products/stablecoin-gateway/apps/web/src/App.tsx
+++ b/products/stablecoin-gateway/apps/web/src/App.tsx
@@ -15,6 +15,8 @@ import ApiKeys from './pages/dashboard/ApiKeys';
 import Webhooks from './pages/dashboard/Webhooks';
 import Security from './pages/dashboard/Security';
 import Login from './pages/auth/Login';
+import Signup from './pages/auth/Signup';
+import ProtectedRoute from './components/ProtectedRoute';
 import ErrorBoundary from './components/ErrorBoundary';
 
 // Create a query client for React Query
@@ -39,16 +41,19 @@ function App() {
               <Route path="/pay/:id" element={<PaymentPage />} />
               <Route path="/status/:id" element={<StatusPage />} />
               <Route path="/login" element={<Login />} />
+              <Route path="/signup" element={<Signup />} />
 
-              {/* Dashboard routes */}
-              <Route path="/dashboard" element={<DashboardLayout />}>
-                <Route index element={<DashboardHome />} />
-                <Route path="payments" element={<PaymentsList />} />
-                <Route path="invoices" element={<Invoices />} />
-                <Route path="api-keys" element={<ApiKeys />} />
-                <Route path="webhooks" element={<Webhooks />} />
-                <Route path="security" element={<Security />} />
-                <Route path="settings" element={<Settings />} />
+              {/* Dashboard routes (protected) */}
+              <Route element={<ProtectedRoute />}>
+                <Route path="/dashboard" element={<DashboardLayout />}>
+                  <Route index element={<DashboardHome />} />
+                  <Route path="payments" element={<PaymentsList />} />
+                  <Route path="invoices" element={<Invoices />} />
+                  <Route path="api-keys" element={<ApiKeys />} />
+                  <Route path="webhooks" element={<Webhooks />} />
+                  <Route path="security" element={<Security />} />
+                  <Route path="settings" element={<Settings />} />
+                </Route>
               </Route>
             </Routes>
           </Router>

--- a/products/stablecoin-gateway/apps/web/src/components/ProtectedRoute.tsx
+++ b/products/stablecoin-gateway/apps/web/src/components/ProtectedRoute.tsx
@@ -1,0 +1,17 @@
+/**
+ * ProtectedRoute
+ *
+ * Auth guard that redirects unauthenticated users to /login.
+ * Checks for an existing token via TokenManager.
+ */
+
+import { Navigate, Outlet } from 'react-router-dom';
+import { TokenManager } from '../lib/token-manager';
+
+export default function ProtectedRoute() {
+  if (!TokenManager.hasToken()) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return <Outlet />;
+}

--- a/products/stablecoin-gateway/apps/web/src/pages/auth/Signup.tsx
+++ b/products/stablecoin-gateway/apps/web/src/pages/auth/Signup.tsx
@@ -1,0 +1,213 @@
+/**
+ * Signup Page
+ *
+ * Handles new user registration with email and password.
+ * Enforces password requirements and redirects to dashboard on success.
+ */
+
+import { useState } from 'react';
+import type { FormEvent } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { apiClient } from '../../lib/api-client';
+
+const PASSWORD_REQUIREMENTS = [
+  { label: 'At least 12 characters', test: (p: string) => p.length >= 12 },
+  { label: 'One uppercase letter', test: (p: string) => /[A-Z]/.test(p) },
+  { label: 'One lowercase letter', test: (p: string) => /[a-z]/.test(p) },
+  { label: 'One number', test: (p: string) => /[0-9]/.test(p) },
+  { label: 'One special character', test: (p: string) => /[^A-Za-z0-9]/.test(p) },
+];
+
+export default function Signup() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const navigate = useNavigate();
+
+  const allRequirementsMet = PASSWORD_REQUIREMENTS.every(r => r.test(password));
+  const passwordsMatch = password === confirmPassword && confirmPassword.length > 0;
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!allRequirementsMet) {
+      setError('Password does not meet all requirements');
+      return;
+    }
+
+    if (!passwordsMatch) {
+      setError('Passwords do not match');
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      await apiClient.signup(email, password);
+      navigate('/dashboard');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Signup failed';
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-md w-full space-y-8">
+        <div>
+          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+            Create your account
+          </h2>
+          <p className="mt-2 text-center text-sm text-gray-600">
+            Get started with your merchant dashboard
+          </p>
+        </div>
+
+        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
+          {error && (
+            <div
+              className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded relative"
+              role="alert"
+            >
+              <span className="block sm:inline">{error}</span>
+            </div>
+          )}
+
+          <div className="rounded-md shadow-sm -space-y-px">
+            <div>
+              <label htmlFor="email" className="sr-only">
+                Email address
+              </label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                autoComplete="email"
+                required
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm"
+                placeholder="Email address"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                disabled={isLoading}
+              />
+            </div>
+            <div>
+              <label htmlFor="password" className="sr-only">
+                Password
+              </label>
+              <input
+                id="password"
+                name="password"
+                type="password"
+                autoComplete="new-password"
+                required
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm"
+                placeholder="Password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                disabled={isLoading}
+              />
+            </div>
+            <div>
+              <label htmlFor="confirm-password" className="sr-only">
+                Confirm password
+              </label>
+              <input
+                id="confirm-password"
+                name="confirm-password"
+                type="password"
+                autoComplete="new-password"
+                required
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm"
+                placeholder="Confirm password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                disabled={isLoading}
+              />
+            </div>
+          </div>
+
+          {/* Password requirements */}
+          <div className="bg-gray-50 border border-gray-200 rounded-md p-4">
+            <p className="text-xs font-medium text-gray-700 mb-2">Password requirements:</p>
+            <ul className="space-y-1">
+              {PASSWORD_REQUIREMENTS.map((req) => {
+                const met = req.test(password);
+                return (
+                  <li
+                    key={req.label}
+                    className={`text-xs flex items-center gap-1.5 ${
+                      met ? 'text-green-600' : 'text-gray-500'
+                    }`}
+                  >
+                    <span>{met ? '\u2713' : '\u2022'}</span>
+                    {req.label}
+                  </li>
+                );
+              })}
+            </ul>
+            {confirmPassword.length > 0 && (
+              <p
+                className={`text-xs mt-2 ${
+                  passwordsMatch ? 'text-green-600' : 'text-red-500'
+                }`}
+              >
+                {passwordsMatch ? '\u2713 Passwords match' : 'Passwords do not match'}
+              </p>
+            )}
+          </div>
+
+          <div>
+            <button
+              type="submit"
+              disabled={isLoading || !allRequirementsMet || !passwordsMatch}
+              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isLoading ? (
+                <span className="flex items-center">
+                  <svg
+                    className="animate-spin -ml-1 mr-3 h-5 w-5 text-white"
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                  >
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                    ></circle>
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                    ></path>
+                  </svg>
+                  Creating account...
+                </span>
+              ) : (
+                'Create account'
+              )}
+            </button>
+          </div>
+
+          <div className="text-center">
+            <p className="text-sm text-gray-600">
+              Already have an account?{' '}
+              <Link to="/login" className="font-medium text-blue-600 hover:text-blue-500">
+                Sign in
+              </Link>
+            </p>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Extended api-client.ts with signup, API key CRUD, and webhook CRUD methods
- Created ProtectedRoute component to guard dashboard routes
- Created Signup page with real-time password validation
- Updated App.tsx routes with auth guard and signup route
- Changed default VITE_USE_MOCK_API to false

## Test plan
- [ ] Verify signup flow creates account via backend
- [ ] Verify login redirects to dashboard
- [ ] Verify unauthenticated access redirects to /login
- [ ] Verify API key and webhook client methods work against backend
- [ ] Verify mock mode still works when VITE_USE_MOCK_API=true

🤖 Generated with [Claude Code](https://claude.com/claude-code)