### PR TITLE
feat(stablecoin): build API Keys & Webhooks CRUD pages

### DIFF
--- a/products/stablecoin-gateway/apps/web/src/hooks/useApiKeys.ts
+++ b/products/stablecoin-gateway/apps/web/src/hooks/useApiKeys.ts
@@ -1,0 +1,75 @@
+import { useState, useEffect, useCallback } from 'react';
+import { apiClient, type ApiKeyResponse, type CreateApiKeyRequest } from '../lib/api-client';
+
+interface UseApiKeysReturn {
+  apiKeys: ApiKeyResponse[];
+  isLoading: boolean;
+  error: string | null;
+  createdKey: ApiKeyResponse | null;
+  createApiKey: (data: CreateApiKeyRequest) => Promise<void>;
+  deleteApiKey: (id: string) => Promise<void>;
+  clearCreatedKey: () => void;
+}
+
+export function useApiKeys(): UseApiKeysReturn {
+  const [apiKeys, setApiKeys] = useState<ApiKeyResponse[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [createdKey, setCreatedKey] = useState<ApiKeyResponse | null>(null);
+
+  const loadApiKeys = useCallback(async () => {
+    try {
+      setError(null);
+      const result = await apiClient.listApiKeys();
+      setApiKeys(result.data);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to load API keys';
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadApiKeys();
+  }, [loadApiKeys]);
+
+  const createApiKey = useCallback(async (data: CreateApiKeyRequest) => {
+    setError(null);
+    try {
+      const newKey = await apiClient.createApiKey(data);
+      setCreatedKey(newKey);
+      await loadApiKeys();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to create API key';
+      setError(message);
+      throw err;
+    }
+  }, [loadApiKeys]);
+
+  const deleteApiKey = useCallback(async (id: string) => {
+    setError(null);
+    try {
+      await apiClient.deleteApiKey(id);
+      setApiKeys(prev => prev.filter(k => k.id !== id));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to delete API key';
+      setError(message);
+      throw err;
+    }
+  }, []);
+
+  const clearCreatedKey = useCallback(() => {
+    setCreatedKey(null);
+  }, []);
+
+  return {
+    apiKeys,
+    isLoading,
+    error,
+    createdKey,
+    createApiKey,
+    deleteApiKey,
+    clearCreatedKey,
+  };
+}

--- a/products/stablecoin-gateway/apps/web/src/hooks/useWebhooks.ts
+++ b/products/stablecoin-gateway/apps/web/src/hooks/useWebhooks.ts
@@ -1,0 +1,131 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  apiClient,
+  type WebhookResponse,
+  type CreateWebhookRequest,
+  type UpdateWebhookRequest,
+} from '../lib/api-client';
+
+interface UseWebhooksReturn {
+  webhooks: WebhookResponse[];
+  isLoading: boolean;
+  error: string | null;
+  createdWebhook: WebhookResponse | null;
+  rotatedSecret: string | null;
+  createWebhook: (data: CreateWebhookRequest) => Promise<void>;
+  updateWebhook: (id: string, data: UpdateWebhookRequest) => Promise<void>;
+  deleteWebhook: (id: string) => Promise<void>;
+  rotateSecret: (id: string) => Promise<void>;
+  clearCreatedWebhook: () => void;
+  clearRotatedSecret: () => void;
+}
+
+const WEBHOOK_EVENTS = [
+  'payment.created',
+  'payment.confirming',
+  'payment.completed',
+  'payment.failed',
+  'payment.expired',
+  'refund.created',
+  'refund.completed',
+  'refund.failed',
+] as const;
+
+export type WebhookEvent = typeof WEBHOOK_EVENTS[number];
+export { WEBHOOK_EVENTS };
+
+export function useWebhooks(): UseWebhooksReturn {
+  const [webhooks, setWebhooks] = useState<WebhookResponse[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [createdWebhook, setCreatedWebhook] = useState<WebhookResponse | null>(null);
+  const [rotatedSecret, setRotatedSecret] = useState<string | null>(null);
+
+  const loadWebhooks = useCallback(async () => {
+    try {
+      setError(null);
+      const result = await apiClient.listWebhooks();
+      setWebhooks(result.data);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to load webhooks';
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadWebhooks();
+  }, [loadWebhooks]);
+
+  const createWebhook = useCallback(async (data: CreateWebhookRequest) => {
+    setError(null);
+    try {
+      const newWebhook = await apiClient.createWebhook(data);
+      setCreatedWebhook(newWebhook);
+      await loadWebhooks();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to create webhook';
+      setError(message);
+      throw err;
+    }
+  }, [loadWebhooks]);
+
+  const updateWebhook = useCallback(async (id: string, data: UpdateWebhookRequest) => {
+    setError(null);
+    try {
+      const updated = await apiClient.updateWebhook(id, data);
+      setWebhooks(prev => prev.map(w => w.id === id ? updated : w));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to update webhook';
+      setError(message);
+      throw err;
+    }
+  }, []);
+
+  const deleteWebhook = useCallback(async (id: string) => {
+    setError(null);
+    try {
+      await apiClient.deleteWebhook(id);
+      setWebhooks(prev => prev.filter(w => w.id !== id));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to delete webhook';
+      setError(message);
+      throw err;
+    }
+  }, []);
+
+  const rotateSecret = useCallback(async (id: string) => {
+    setError(null);
+    try {
+      const result = await apiClient.rotateWebhookSecret(id);
+      setRotatedSecret(result.secret);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to rotate secret';
+      setError(message);
+      throw err;
+    }
+  }, []);
+
+  const clearCreatedWebhook = useCallback(() => {
+    setCreatedWebhook(null);
+  }, []);
+
+  const clearRotatedSecret = useCallback(() => {
+    setRotatedSecret(null);
+  }, []);
+
+  return {
+    webhooks,
+    isLoading,
+    error,
+    createdWebhook,
+    rotatedSecret,
+    createWebhook,
+    updateWebhook,
+    deleteWebhook,
+    rotateSecret,
+    clearCreatedWebhook,
+    clearRotatedSecret,
+  };
+}

--- a/products/stablecoin-gateway/apps/web/src/pages/dashboard/ApiKeys.tsx
+++ b/products/stablecoin-gateway/apps/web/src/pages/dashboard/ApiKeys.tsx
@@ -1,23 +1,277 @@
+import { useState } from 'react';
+import type { FormEvent } from 'react';
+import { useApiKeys } from '../../hooks/useApiKeys';
+
 export default function ApiKeys() {
+  const {
+    apiKeys,
+    isLoading,
+    error,
+    createdKey,
+    createApiKey,
+    deleteApiKey,
+    clearCreatedKey,
+  } = useApiKeys();
+
+  const [showForm, setShowForm] = useState(false);
+  const [name, setName] = useState('');
+  const [permRead, setPermRead] = useState(true);
+  const [permWrite, setPermWrite] = useState(false);
+  const [permRefund, setPermRefund] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const handleCreate = async (e: FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    try {
+      await createApiKey({
+        name,
+        permissions: { read: permRead, write: permWrite, refund: permRefund },
+      });
+      setName('');
+      setPermRead(true);
+      setPermWrite(false);
+      setPermRefund(false);
+      setShowForm(false);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    await deleteApiKey(id);
+    setDeleteConfirm(null);
+  };
+
+  const handleCopyKey = async (key: string) => {
+    await navigator.clipboard.writeText(key);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
   return (
     <div className="space-y-6">
-      <div>
-        <h2 className="text-2xl font-bold text-text-primary mb-1">API Keys</h2>
-        <p className="text-text-secondary">
-          Manage your API keys for programmatic access
-        </p>
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold text-text-primary mb-1">API Keys</h2>
+          <p className="text-text-secondary">
+            Manage your API keys for programmatic access
+          </p>
+        </div>
+        <button
+          onClick={() => { setShowForm(true); clearCreatedKey(); }}
+          className="px-4 py-2 text-sm font-medium text-white bg-accent-blue hover:bg-blue-600 rounded-lg transition-colors"
+        >
+          Create API Key
+        </button>
       </div>
 
-      <div className="bg-card-bg border border-card-border rounded-xl p-8 text-center">
-        <div className="text-4xl mb-3">
-          <svg className="w-12 h-12 mx-auto text-text-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 5.25a3 3 0 0 1 3 3m3 0a6 6 0 0 1-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1 1 21.75 8.25Z" />
-          </svg>
+      {error && (
+        <div className="bg-red-500/10 border border-red-500/30 text-red-400 px-4 py-3 rounded-lg">
+          {error}
         </div>
-        <h3 className="text-lg font-semibold text-text-primary mb-2">Coming Soon</h3>
-        <p className="text-text-secondary text-sm max-w-md mx-auto">
-          Generate and manage API keys for secure programmatic access to StableFlow services.
-        </p>
+      )}
+
+      {/* Created key banner — show full key once */}
+      {createdKey?.key && (
+        <div className="bg-green-500/10 border border-green-500/30 rounded-xl p-4 space-y-3">
+          <div className="flex items-start gap-3">
+            <svg className="w-5 h-5 text-accent-green mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-accent-green">API Key Created</p>
+              <p className="text-xs text-text-secondary mt-1">
+                Copy this key now. You won't be able to see it again.
+              </p>
+              <div className="mt-2 flex items-center gap-2">
+                <code className="flex-1 text-xs font-mono bg-page-bg px-3 py-2 rounded border border-card-border text-text-primary break-all">
+                  {createdKey.key}
+                </code>
+                <button
+                  onClick={() => handleCopyKey(createdKey.key!)}
+                  className="px-3 py-2 text-xs font-medium text-text-secondary border border-card-border rounded hover:text-text-primary hover:border-text-muted transition-colors flex-shrink-0"
+                >
+                  {copied ? 'Copied!' : 'Copy'}
+                </button>
+              </div>
+            </div>
+          </div>
+          <div className="flex justify-end">
+            <button
+              onClick={clearCreatedKey}
+              className="text-xs text-text-muted hover:text-text-secondary transition-colors"
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Create form */}
+      {showForm && (
+        <div className="bg-card-bg border border-card-border rounded-xl p-6">
+          <h3 className="text-lg font-semibold text-text-primary mb-4">Create New API Key</h3>
+          <form onSubmit={handleCreate} className="space-y-4">
+            <div>
+              <label htmlFor="key-name" className="block text-sm font-medium text-text-secondary mb-1">
+                Key Name
+              </label>
+              <input
+                id="key-name"
+                type="text"
+                required
+                placeholder="e.g., Production Server"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                className="w-full px-3 py-2 text-sm bg-page-bg border border-card-border rounded-lg text-text-primary placeholder-text-muted focus:outline-none focus:border-accent-blue"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-text-secondary mb-2">
+                Permissions
+              </label>
+              <div className="space-y-2">
+                <label className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={permRead}
+                    onChange={(e) => setPermRead(e.target.checked)}
+                    className="rounded border-card-border"
+                  />
+                  <span className="text-sm text-text-primary">Read</span>
+                  <span className="text-xs text-text-muted">— View payments and balances</span>
+                </label>
+                <label className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={permWrite}
+                    onChange={(e) => setPermWrite(e.target.checked)}
+                    className="rounded border-card-border"
+                  />
+                  <span className="text-sm text-text-primary">Write</span>
+                  <span className="text-xs text-text-muted">— Create payment sessions</span>
+                </label>
+                <label className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={permRefund}
+                    onChange={(e) => setPermRefund(e.target.checked)}
+                    className="rounded border-card-border"
+                  />
+                  <span className="text-sm text-text-primary">Refund</span>
+                  <span className="text-xs text-text-muted">— Issue refunds</span>
+                </label>
+              </div>
+            </div>
+
+            <div className="flex gap-3 pt-2">
+              <button
+                type="submit"
+                disabled={isSubmitting || !name.trim()}
+                className="px-4 py-2 text-sm font-medium text-white bg-accent-blue hover:bg-blue-600 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isSubmitting ? 'Creating...' : 'Create Key'}
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowForm(false)}
+                className="px-4 py-2 text-sm font-medium text-text-secondary border border-card-border rounded-lg hover:text-text-primary hover:border-text-muted transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {/* Keys table */}
+      <div className="bg-card-bg border border-card-border rounded-xl overflow-hidden">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-card-border">
+              <th className="text-left px-6 py-3.5 text-text-muted font-medium">Name</th>
+              <th className="text-left px-6 py-3.5 text-text-muted font-medium">Key</th>
+              <th className="text-left px-6 py-3.5 text-text-muted font-medium">Permissions</th>
+              <th className="text-left px-6 py-3.5 text-text-muted font-medium">Created</th>
+              <th className="text-left px-6 py-3.5 text-text-muted font-medium">Last Used</th>
+              <th className="text-right px-6 py-3.5 text-text-muted font-medium">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading ? (
+              <tr>
+                <td colSpan={6} className="px-6 py-8 text-center text-text-secondary">
+                  Loading API keys...
+                </td>
+              </tr>
+            ) : apiKeys.length === 0 ? (
+              <tr>
+                <td colSpan={6} className="px-6 py-8 text-center text-text-secondary">
+                  No API keys yet. Create one to get started.
+                </td>
+              </tr>
+            ) : (
+              apiKeys.map((key) => (
+                <tr key={key.id} className="border-b border-card-border last:border-b-0">
+                  <td className="px-6 py-4 text-text-primary font-medium">{key.name}</td>
+                  <td className="px-6 py-4 font-mono text-text-secondary text-xs">{key.key_prefix}</td>
+                  <td className="px-6 py-4">
+                    <div className="flex gap-1.5">
+                      {Object.entries(key.permissions)
+                        .filter(([, v]) => v)
+                        .map(([perm]) => (
+                          <span
+                            key={perm}
+                            className="inline-block px-2 py-0.5 rounded text-xs font-medium bg-accent-blue/15 text-accent-blue border border-accent-blue/30"
+                          >
+                            {perm}
+                          </span>
+                        ))}
+                    </div>
+                  </td>
+                  <td className="px-6 py-4 text-text-secondary">
+                    {new Date(key.created_at).toLocaleDateString()}
+                  </td>
+                  <td className="px-6 py-4 text-text-secondary">
+                    {key.last_used_at
+                      ? new Date(key.last_used_at).toLocaleDateString()
+                      : 'Never'}
+                  </td>
+                  <td className="px-6 py-4 text-right">
+                    {deleteConfirm === key.id ? (
+                      <div className="flex items-center justify-end gap-2">
+                        <span className="text-xs text-red-400">Revoke?</span>
+                        <button
+                          onClick={() => handleDelete(key.id)}
+                          className="px-2 py-1 text-xs font-medium text-red-400 border border-red-500/30 rounded hover:bg-red-500/10 transition-colors"
+                        >
+                          Confirm
+                        </button>
+                        <button
+                          onClick={() => setDeleteConfirm(null)}
+                          className="px-2 py-1 text-xs font-medium text-text-muted border border-card-border rounded hover:text-text-secondary transition-colors"
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    ) : (
+                      <button
+                        onClick={() => setDeleteConfirm(key.id)}
+                        className="px-3 py-1 text-xs font-medium text-red-400 border border-red-500/30 rounded hover:bg-red-500/10 transition-colors"
+                      >
+                        Revoke
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
       </div>
     </div>
   );

--- a/products/stablecoin-gateway/apps/web/src/pages/dashboard/Webhooks.tsx
+++ b/products/stablecoin-gateway/apps/web/src/pages/dashboard/Webhooks.tsx
@@ -1,24 +1,386 @@
+import { useState } from 'react';
+import type { FormEvent } from 'react';
+import { useWebhooks, WEBHOOK_EVENTS } from '../../hooks/useWebhooks';
+
 export default function Webhooks() {
+  const {
+    webhooks,
+    isLoading,
+    error,
+    createdWebhook,
+    rotatedSecret,
+    createWebhook,
+    updateWebhook,
+    deleteWebhook,
+    rotateSecret,
+    clearCreatedWebhook,
+    clearRotatedSecret,
+  } = useWebhooks();
+
+  const [showForm, setShowForm] = useState(false);
+  const [url, setUrl] = useState('');
+  const [description, setDescription] = useState('');
+  const [selectedEvents, setSelectedEvents] = useState<string[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editUrl, setEditUrl] = useState('');
+  const [editDescription, setEditDescription] = useState('');
+  const [editEvents, setEditEvents] = useState<string[]>([]);
+  const [copied, setCopied] = useState(false);
+
+  const handleCreate = async (e: FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    try {
+      await createWebhook({
+        url,
+        events: selectedEvents,
+        description: description || undefined,
+      });
+      setUrl('');
+      setDescription('');
+      setSelectedEvents([]);
+      setShowForm(false);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleToggleEvent = (event: string) => {
+    setSelectedEvents(prev =>
+      prev.includes(event)
+        ? prev.filter(e => e !== event)
+        : [...prev, event]
+    );
+  };
+
+  const handleEditToggleEvent = (event: string) => {
+    setEditEvents(prev =>
+      prev.includes(event)
+        ? prev.filter(e => e !== event)
+        : [...prev, event]
+    );
+  };
+
+  const handleStartEdit = (webhook: typeof webhooks[0]) => {
+    setEditingId(webhook.id);
+    setEditUrl(webhook.url);
+    setEditDescription(webhook.description || '');
+    setEditEvents([...webhook.events]);
+  };
+
+  const handleSaveEdit = async () => {
+    if (!editingId) return;
+    await updateWebhook(editingId, {
+      url: editUrl,
+      description: editDescription || undefined,
+      events: editEvents,
+    });
+    setEditingId(null);
+  };
+
+  const handleToggleEnabled = async (id: string, enabled: boolean) => {
+    await updateWebhook(id, { enabled: !enabled });
+  };
+
+  const handleDelete = async (id: string) => {
+    await deleteWebhook(id);
+    setDeleteConfirm(null);
+  };
+
+  const handleCopySecret = async (secret: string) => {
+    await navigator.clipboard.writeText(secret);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const secretBanner = createdWebhook?.secret || rotatedSecret;
+  const secretLabel = createdWebhook?.secret ? 'Webhook Created' : 'Secret Rotated';
+
   return (
     <div className="space-y-6">
-      <div>
-        <h2 className="text-2xl font-bold text-text-primary mb-1">Webhooks & Docs</h2>
-        <p className="text-text-secondary">
-          Configure webhook endpoints and view API documentation
-        </p>
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold text-text-primary mb-1">Webhooks</h2>
+          <p className="text-text-secondary">
+            Configure endpoints to receive real-time payment notifications
+          </p>
+        </div>
+        <button
+          onClick={() => { setShowForm(true); clearCreatedWebhook(); clearRotatedSecret(); }}
+          className="px-4 py-2 text-sm font-medium text-white bg-accent-blue hover:bg-blue-600 rounded-lg transition-colors"
+        >
+          Add Webhook
+        </button>
       </div>
 
-      <div className="bg-card-bg border border-card-border rounded-xl p-8 text-center">
-        <div className="text-4xl mb-3">
-          <svg className="w-12 h-12 mx-auto text-text-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5" />
-          </svg>
+      {error && (
+        <div className="bg-red-500/10 border border-red-500/30 text-red-400 px-4 py-3 rounded-lg">
+          {error}
         </div>
-        <h3 className="text-lg font-semibold text-text-primary mb-2">Coming Soon</h3>
-        <p className="text-text-secondary text-sm max-w-md mx-auto">
-          Configure webhook endpoints to receive real-time payment notifications and browse API documentation.
-        </p>
-      </div>
+      )}
+
+      {/* Secret banner */}
+      {secretBanner && (
+        <div className="bg-green-500/10 border border-green-500/30 rounded-xl p-4 space-y-3">
+          <div className="flex items-start gap-3">
+            <svg className="w-5 h-5 text-accent-green mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-accent-green">{secretLabel}</p>
+              <p className="text-xs text-text-secondary mt-1">
+                Copy this signing secret now. You won't be able to see it again.
+              </p>
+              <div className="mt-2 flex items-center gap-2">
+                <code className="flex-1 text-xs font-mono bg-page-bg px-3 py-2 rounded border border-card-border text-text-primary break-all">
+                  {secretBanner}
+                </code>
+                <button
+                  onClick={() => handleCopySecret(secretBanner)}
+                  className="px-3 py-2 text-xs font-medium text-text-secondary border border-card-border rounded hover:text-text-primary hover:border-text-muted transition-colors flex-shrink-0"
+                >
+                  {copied ? 'Copied!' : 'Copy'}
+                </button>
+              </div>
+            </div>
+          </div>
+          <div className="flex justify-end">
+            <button
+              onClick={() => { clearCreatedWebhook(); clearRotatedSecret(); }}
+              className="text-xs text-text-muted hover:text-text-secondary transition-colors"
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Create form */}
+      {showForm && (
+        <div className="bg-card-bg border border-card-border rounded-xl p-6">
+          <h3 className="text-lg font-semibold text-text-primary mb-4">Add Webhook Endpoint</h3>
+          <form onSubmit={handleCreate} className="space-y-4">
+            <div>
+              <label htmlFor="wh-url" className="block text-sm font-medium text-text-secondary mb-1">
+                Endpoint URL
+              </label>
+              <input
+                id="wh-url"
+                type="url"
+                required
+                placeholder="https://your-server.com/webhooks/stableflow"
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                className="w-full px-3 py-2 text-sm bg-page-bg border border-card-border rounded-lg text-text-primary placeholder-text-muted focus:outline-none focus:border-accent-blue"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="wh-desc" className="block text-sm font-medium text-text-secondary mb-1">
+                Description (optional)
+              </label>
+              <input
+                id="wh-desc"
+                type="text"
+                placeholder="e.g., Production payment notifications"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                className="w-full px-3 py-2 text-sm bg-page-bg border border-card-border rounded-lg text-text-primary placeholder-text-muted focus:outline-none focus:border-accent-blue"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-text-secondary mb-2">
+                Events
+              </label>
+              <div className="grid grid-cols-2 gap-2">
+                {WEBHOOK_EVENTS.map(event => (
+                  <label key={event} className="flex items-center gap-2 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={selectedEvents.includes(event)}
+                      onChange={() => handleToggleEvent(event)}
+                      className="rounded border-card-border"
+                    />
+                    <span className="text-sm text-text-primary font-mono">{event}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            <div className="flex gap-3 pt-2">
+              <button
+                type="submit"
+                disabled={isSubmitting || !url.trim() || selectedEvents.length === 0}
+                className="px-4 py-2 text-sm font-medium text-white bg-accent-blue hover:bg-blue-600 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isSubmitting ? 'Creating...' : 'Create Webhook'}
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowForm(false)}
+                className="px-4 py-2 text-sm font-medium text-text-secondary border border-card-border rounded-lg hover:text-text-primary hover:border-text-muted transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {/* Webhooks list */}
+      {isLoading ? (
+        <div className="bg-card-bg border border-card-border rounded-xl p-8 text-center text-text-secondary">
+          Loading webhooks...
+        </div>
+      ) : webhooks.length === 0 ? (
+        <div className="bg-card-bg border border-card-border rounded-xl p-8 text-center text-text-secondary">
+          No webhooks configured. Add one to start receiving payment notifications.
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {webhooks.map(webhook => (
+            <div key={webhook.id} className="bg-card-bg border border-card-border rounded-xl p-5">
+              {editingId === webhook.id ? (
+                /* Edit mode */
+                <div className="space-y-4">
+                  <div>
+                    <label className="block text-sm font-medium text-text-secondary mb-1">URL</label>
+                    <input
+                      type="url"
+                      value={editUrl}
+                      onChange={(e) => setEditUrl(e.target.value)}
+                      className="w-full px-3 py-2 text-sm bg-page-bg border border-card-border rounded-lg text-text-primary focus:outline-none focus:border-accent-blue"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-text-secondary mb-1">Description</label>
+                    <input
+                      type="text"
+                      value={editDescription}
+                      onChange={(e) => setEditDescription(e.target.value)}
+                      className="w-full px-3 py-2 text-sm bg-page-bg border border-card-border rounded-lg text-text-primary focus:outline-none focus:border-accent-blue"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-text-secondary mb-2">Events</label>
+                    <div className="grid grid-cols-2 gap-2">
+                      {WEBHOOK_EVENTS.map(event => (
+                        <label key={event} className="flex items-center gap-2 cursor-pointer">
+                          <input
+                            type="checkbox"
+                            checked={editEvents.includes(event)}
+                            onChange={() => handleEditToggleEvent(event)}
+                            className="rounded border-card-border"
+                          />
+                          <span className="text-sm text-text-primary font-mono">{event}</span>
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="flex gap-3">
+                    <button
+                      onClick={handleSaveEdit}
+                      className="px-4 py-2 text-sm font-medium text-white bg-accent-blue hover:bg-blue-600 rounded-lg transition-colors"
+                    >
+                      Save
+                    </button>
+                    <button
+                      onClick={() => setEditingId(null)}
+                      className="px-4 py-2 text-sm font-medium text-text-secondary border border-card-border rounded-lg hover:text-text-primary transition-colors"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                /* View mode */
+                <div>
+                  <div className="flex items-start justify-between mb-3">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-3 mb-1">
+                        <code className="text-sm font-mono text-text-primary truncate">{webhook.url}</code>
+                        <span
+                          className={`inline-block px-2 py-0.5 rounded-full text-xs font-semibold border ${
+                            webhook.enabled
+                              ? 'bg-green-500/15 text-accent-green border-green-500/30'
+                              : 'bg-yellow-500/15 text-accent-yellow border-yellow-500/30'
+                          }`}
+                        >
+                          {webhook.enabled ? 'Active' : 'Disabled'}
+                        </span>
+                      </div>
+                      {webhook.description && (
+                        <p className="text-xs text-text-muted">{webhook.description}</p>
+                      )}
+                    </div>
+                  </div>
+
+                  {/* Events */}
+                  <div className="flex flex-wrap gap-1.5 mb-4">
+                    {webhook.events.map(event => (
+                      <span
+                        key={event}
+                        className="inline-block px-2 py-0.5 rounded text-xs font-mono bg-accent-blue/10 text-accent-blue border border-accent-blue/20"
+                      >
+                        {event}
+                      </span>
+                    ))}
+                  </div>
+
+                  {/* Actions */}
+                  <div className="flex items-center gap-2 border-t border-card-border pt-3">
+                    <button
+                      onClick={() => handleToggleEnabled(webhook.id, webhook.enabled)}
+                      className="px-3 py-1 text-xs font-medium text-text-secondary border border-card-border rounded hover:text-text-primary hover:border-text-muted transition-colors"
+                    >
+                      {webhook.enabled ? 'Disable' : 'Enable'}
+                    </button>
+                    <button
+                      onClick={() => handleStartEdit(webhook)}
+                      className="px-3 py-1 text-xs font-medium text-text-secondary border border-card-border rounded hover:text-text-primary hover:border-text-muted transition-colors"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      onClick={() => rotateSecret(webhook.id)}
+                      className="px-3 py-1 text-xs font-medium text-accent-yellow border border-yellow-500/30 rounded hover:bg-yellow-500/10 transition-colors"
+                    >
+                      Rotate Secret
+                    </button>
+                    {deleteConfirm === webhook.id ? (
+                      <>
+                        <span className="text-xs text-red-400 ml-2">Delete?</span>
+                        <button
+                          onClick={() => handleDelete(webhook.id)}
+                          className="px-2 py-1 text-xs font-medium text-red-400 border border-red-500/30 rounded hover:bg-red-500/10 transition-colors"
+                        >
+                          Confirm
+                        </button>
+                        <button
+                          onClick={() => setDeleteConfirm(null)}
+                          className="px-2 py-1 text-xs font-medium text-text-muted border border-card-border rounded hover:text-text-secondary transition-colors"
+                        >
+                          Cancel
+                        </button>
+                      </>
+                    ) : (
+                      <button
+                        onClick={() => setDeleteConfirm(webhook.id)}
+                        className="px-3 py-1 text-xs font-medium text-red-400 border border-red-500/30 rounded hover:bg-red-500/10 transition-colors"
+                      >
+                        Delete
+                      </button>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replace placeholder "Coming Soon" API Keys page with full CRUD table (create, copy key, revoke)
- Replace placeholder "Coming Soon" Webhooks page with full CRUD cards (create, edit, enable/disable, delete, rotate secret)
- Add `useApiKeys` and `useWebhooks` hooks encapsulating all state and API calls
- Both pages show one-time secrets with copy-to-clipboard and dismiss

## Test plan
- [ ] Create an API key with read+write permissions, verify key is shown once
- [ ] Copy key to clipboard, dismiss banner, verify key no longer visible
- [ ] Revoke a key with confirmation dialog
- [ ] Create a webhook with URL and selected events, verify secret shown once
- [ ] Edit webhook URL and events, save changes
- [ ] Toggle webhook enabled/disabled
- [ ] Rotate webhook secret, verify new secret shown
- [ ] Delete webhook with confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)