### PR TITLE
fix(infra): make E2E tests mandatory in quality gates

### DIFF
--- a/.claude/agents/qa-engineer.md
+++ b/.claude/agents/qa-engineer.md
@@ -82,7 +82,29 @@ This script automatically:
 or "Not yet implemented" is a FAIL. Placeholder pages mean the product is not
 shippable, regardless of how many unit tests pass.
 
-### Step 4: Visual Verification
+### Step 4: Interactive Element Verification (MANDATORY)
+**This step catches bugs that static checks miss** — buttons that render but don't work,
+dropdowns that don't open, sign-out that doesn't redirect. These are the bugs the CEO
+finds during live demos.
+
+For EVERY interactive element on EVERY page, verify:
+- [ ] **Buttons**: Each button has a working onClick handler (not just styled, actually clickable and does something)
+- [ ] **Navigation**: Every sidebar/nav link navigates to the correct page
+- [ ] **Sign out**: Clicking sign out redirects to /login (test from EVERY sign out location)
+- [ ] **Forms**: Submit buttons are wired to real API calls (not placeholder)
+- [ ] **Dropdowns**: Click to open, items inside are clickable and navigate/act correctly
+- [ ] **User context**: User info (email, initials, name) comes from real auth state, not hardcoded
+- [ ] **CRUD operations**: Create/Read/Update/Delete buttons actually call the API
+
+**How to verify**: The E2E tests should cover all of these. If an interactive element
+exists on any page but has NO corresponding E2E test, that is a **FAIL**. Every clickable
+element must have an E2E test that clicks it and verifies the result.
+
+If ANY interactive element is broken or untested:
+- **FAIL** the testing gate
+- Route to Frontend Engineer to fix the element AND add E2E test coverage
+
+### Step 5: Visual Verification
 With dev server running (smoke test leaves it running), verify:
 - [ ] App loads without errors
 - [ ] All buttons visible and styled (have background color)
@@ -98,7 +120,8 @@ TESTING GATE PASSED - Ready for CEO checkpoint
 
 Results:
 - Unit tests: PASS (X tests)
-- E2E tests: PASS (X tests)
+- E2E tests: PASS (X tests across Y spec files)
+- Interactive element verification: PASS (all buttons/nav/forms tested by E2E)
 - Smoke test: PASS (servers start, health OK, UI loads, no placeholders)
 - Visual verification: PASS
 
@@ -111,7 +134,8 @@ TESTING GATE FAILED - Not ready for CEO
 
 Results:
 - Unit tests: [PASS/FAIL]
-- E2E tests: [PASS/FAIL]
+- E2E tests: [PASS/FAIL] (X tests across Y spec files)
+- Interactive element verification: [PASS/FAIL]
 - Smoke test: [PASS/FAIL]
 - Visual verification: [PASS/FAIL]
 

--- a/.claude/orchestrator/orchestrator-enhanced.md
+++ b/.claude/orchestrator/orchestrator-enhanced.md
@@ -256,7 +256,11 @@ F. CHECK FOR CHECKPOINT
        - Continue execution loop (improvements first)
        - Re-audit after improvements
        - Repeat until all scores >= 8/10
-     - **All pass condition**: smoke test PASS + no placeholders + testing gate PASS + all audit scores >= 8/10
+     - **E2E Test Existence Check**: Before proceeding, verify the product has >= 3 Playwright
+       E2E test files. If not, route to QA Engineer to write them. Products without E2E tests
+       CANNOT pass the checkpoint — this is non-negotiable. Interactive bugs (broken buttons,
+       missing navigation, hardcoded values) are only caught by E2E tests.
+     - **All pass condition**: smoke test PASS + no placeholders + E2E tests exist and pass + testing gate PASS + all audit scores >= 8/10
      - Once all pass:
        - PAUSE execution loop
        - Generate CEO report with audit scores + smoke test report


### PR DESCRIPTION
## Summary

The CEO found 4 broken UI elements (sign out, simulate payment, user icon, navigation) that passed all existing quality gates. This PR fixes the systemic gap.

**Root cause**: E2E tests were optional, the Playwright headless check was a soft warning, and no gate verified that interactive elements actually work. A product could score 9/10 on audit while having non-functional buttons.

## Changes

- **smoke-test-gate.sh**: Playwright headless check is now MANDATORY (FAIL, not WARN). New Check 7 requires >= 3 E2E test files for any web app.
- **testing-gate-checklist.sh**: E2E phase is now REQUIRED (was optional/warn). Missing e2e directory is a hard FAIL. Minimum file count enforced.
- **qa-engineer.md**: New Step 4 "Interactive Element Verification" — requires every button, nav link, dropdown, and form to have a corresponding E2E test. Untested interactive elements = FAIL.
- **orchestrator-enhanced.md**: Checkpoint flow now requires E2E test existence before allowing pass. Products without E2E tests cannot reach CEO checkpoint.

## What this prevents

A product can no longer:
- Pass quality gates with zero E2E tests
- Have buttons that render but don't work
- Have hardcoded user info instead of real auth state
- Have navigation links that go nowhere

## Test plan

- [ ] Verify smoke-test-gate.sh fails when Playwright is not installed
- [ ] Verify testing-gate-checklist.sh fails when no e2e/ directory exists
- [ ] Verify a product with < 3 E2E files gets flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)