### PR TITLE
fix(stablecoin): fix checkout amount, status display, and dev simulation

### DIFF
--- a/products/stablecoin-gateway/apps/api/src/app.ts
+++ b/products/stablecoin-gateway/apps/api/src/app.ts
@@ -21,6 +21,7 @@ import webhookRoutes from './routes/v1/webhooks.js';
 import apiKeyRoutes from './routes/v1/api-keys.js';
 import refundRoutes from './routes/v1/refunds.js';
 import adminRoutes from './routes/v1/admin.js';
+import checkoutRoutes from './routes/v1/checkout.js';
 import webhookWorkerRoutes from './routes/internal/webhook-worker.js';
 
 // Utils
@@ -228,6 +229,13 @@ export async function buildApp(): Promise<FastifyInstance> {
   await fastify.register(apiKeyRoutes, { prefix: '/v1/api-keys' });
   await fastify.register(refundRoutes, { prefix: '/v1/refunds' });
   await fastify.register(adminRoutes, { prefix: '/v1/admin' });
+  await fastify.register(checkoutRoutes, { prefix: '/v1/checkout' });
+
+  // Dev-only routes (never registered in production)
+  if (process.env.NODE_ENV !== 'production') {
+    const devRoutes = (await import('./routes/v1/dev.js')).default;
+    await fastify.register(devRoutes, { prefix: '/v1/dev' });
+  }
 
   // Internal routes (for cron jobs, workers, etc.)
   await fastify.register(webhookWorkerRoutes, { prefix: '/internal' });

--- a/products/stablecoin-gateway/apps/api/src/routes/v1/checkout.ts
+++ b/products/stablecoin-gateway/apps/api/src/routes/v1/checkout.ts
@@ -1,0 +1,57 @@
+import { FastifyPluginAsync } from 'fastify';
+import { logger } from '../../utils/logger.js';
+
+/**
+ * Public checkout routes - no authentication required.
+ * These endpoints return minimal payment info for the customer-facing checkout UI.
+ */
+const checkoutRoutes: FastifyPluginAsync = async (fastify) => {
+  // GET /v1/checkout/:id - Public endpoint for checkout page
+  fastify.get('/:id', async (request, reply) => {
+    const { id } = request.params as { id: string };
+
+    const session = await fastify.prisma.paymentSession.findUnique({
+      where: { id },
+    });
+
+    if (!session) {
+      return reply.code(404).send({
+        type: 'https://gateway.io/errors/payment-not-found',
+        title: 'Payment Not Found',
+        status: 404,
+        detail: 'Payment session not found',
+      });
+    }
+
+    // Check expiry
+    if (session.expiresAt < new Date()) {
+      return reply.code(410).send({
+        type: 'https://gateway.io/errors/payment-expired',
+        title: 'Payment Expired',
+        status: 410,
+        detail: 'This payment session has expired',
+      });
+    }
+
+    // Return only the fields needed for the checkout UI
+    // No sensitive merchant data, no internal IDs beyond the session ID
+    return reply.send({
+      id: session.id,
+      amount: Number(session.amount),
+      currency: session.currency,
+      description: session.description,
+      status: session.status,
+      network: session.network,
+      token: session.token,
+      merchant_address: session.merchantAddress,
+      customer_address: session.customerAddress,
+      tx_hash: session.txHash,
+      confirmations: session.confirmations,
+      checkout_url: `${process.env.FRONTEND_URL || 'http://localhost:3104'}/pay/${session.id}`,
+      created_at: session.createdAt.toISOString(),
+      expires_at: session.expiresAt.toISOString(),
+    });
+  });
+};
+
+export default checkoutRoutes;

--- a/products/stablecoin-gateway/apps/api/src/routes/v1/dev.ts
+++ b/products/stablecoin-gateway/apps/api/src/routes/v1/dev.ts
@@ -1,0 +1,98 @@
+import { FastifyPluginAsync } from 'fastify';
+import { logger } from '../../utils/logger.js';
+
+/**
+ * Development-only routes for simulating payment flows.
+ * Bypasses blockchain verification. NEVER registered in production.
+ */
+const devRoutes: FastifyPluginAsync = async (fastify) => {
+  // POST /v1/dev/simulate/:id — advance a payment to COMPLETED
+  fastify.post('/simulate/:id', async (request, reply) => {
+    const { id } = request.params as { id: string };
+
+    const session = await fastify.prisma.paymentSession.findUnique({
+      where: { id },
+    });
+
+    if (!session) {
+      return reply.code(404).send({
+        type: 'https://gateway.io/errors/payment-not-found',
+        title: 'Payment Not Found',
+        status: 404,
+        detail: 'Payment session not found',
+      });
+    }
+
+    if (session.status === 'COMPLETED') {
+      return reply.send({
+        id: session.id,
+        status: session.status,
+        message: 'Payment already completed',
+      });
+    }
+
+    if (session.status === 'FAILED' || session.status === 'REFUNDED') {
+      return reply.code(400).send({
+        type: 'https://gateway.io/errors/invalid-state',
+        title: 'Invalid State',
+        status: 400,
+        detail: `Cannot simulate payment in ${session.status} state`,
+      });
+    }
+
+    const fakeTxHash = '0xsim' + Array.from({ length: 60 }, () =>
+      Math.floor(Math.random() * 16).toString(16)
+    ).join('');
+    const fakeCustomer = '0x' + Array.from({ length: 40 }, () =>
+      Math.floor(Math.random() * 16).toString(16)
+    ).join('');
+
+    // Advance PENDING → CONFIRMING first
+    if (session.status === 'PENDING') {
+      await fastify.prisma.paymentSession.update({
+        where: { id },
+        data: {
+          status: 'CONFIRMING',
+          txHash: fakeTxHash,
+          customerAddress: fakeCustomer,
+          blockNumber: 12345678,
+          confirmations: 1,
+        },
+      });
+    }
+
+    // Advance to COMPLETED
+    const updated = await fastify.prisma.paymentSession.update({
+      where: { id },
+      data: {
+        status: 'COMPLETED',
+        txHash: session.txHash || fakeTxHash,
+        customerAddress: session.customerAddress || fakeCustomer,
+        blockNumber: session.blockNumber || 12345678,
+        confirmations: 12,
+        completedAt: new Date(),
+      },
+    });
+
+    logger.info('Payment simulated to COMPLETED (dev mode)', {
+      paymentSessionId: id,
+      txHash: updated.txHash,
+    });
+
+    return reply.send({
+      id: updated.id,
+      amount: Number(updated.amount),
+      currency: updated.currency,
+      status: updated.status,
+      network: updated.network,
+      token: updated.token,
+      merchant_address: updated.merchantAddress,
+      customer_address: updated.customerAddress,
+      tx_hash: updated.txHash,
+      confirmations: updated.confirmations,
+      completed_at: updated.completedAt?.toISOString(),
+    });
+  });
+};
+
+export default devRoutes;

--- a/products/stablecoin-gateway/apps/api/src/services/payment.service.ts
+++ b/products/stablecoin-gateway/apps/api/src/services/payment.service.ts
@@ -306,7 +306,7 @@ export class PaymentService {
       tx_hash: session.txHash,
       block_number: session.blockNumber,
       confirmations: session.confirmations,
-      checkout_url: `${baseUrl}/checkout/${session.id}`,
+      checkout_url: `${baseUrl}/pay/${session.id}`,
       success_url: session.successUrl,
       cancel_url: session.cancelUrl,
       metadata: session.metadata as any,

--- a/products/stablecoin-gateway/apps/merchant-demo/src/App.tsx
+++ b/products/stablecoin-gateway/apps/merchant-demo/src/App.tsx
@@ -39,10 +39,10 @@ export default function App() {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'X-API-Key': apiKey,
+          'Authorization': `Bearer ${apiKey}`,
         },
         body: JSON.stringify({
-          amount: 2500,
+          amount: 25,
           currency: 'USD',
           description: 'Premium Widget',
           network: 'polygon',
@@ -74,7 +74,7 @@ export default function App() {
     setIsLoading(true);
     try {
       const response = await fetch(`${apiUrl}/v1/payment-sessions/${payment.id}`, {
-        headers: { 'X-API-Key': apiKey },
+        headers: { 'Authorization': `Bearer ${apiKey}` },
       });
       const updated: PaymentSession = await response.json();
       setPayment(updated);
@@ -225,7 +225,7 @@ export default function App() {
 
           <div style={{ background: 'white', border: '1px solid #e5e7eb', borderRadius: 8, padding: '1rem', marginTop: '1rem', fontFamily: 'monospace', fontSize: '0.8rem' }}>
             <div><strong>Session ID:</strong> {payment.id}</div>
-            <div><strong>Amount:</strong> ${(payment.amount / 100).toFixed(2)} {payment.currency}</div>
+            <div><strong>Amount:</strong> ${payment.amount.toFixed(2)} {payment.currency}</div>
             <div><strong>Status:</strong> <span style={{ color: payment.status === 'completed' ? '#16a34a' : '#d97706' }}>{payment.status.toUpperCase()}</span></div>
             <div><strong>Checkout URL:</strong> <a href={payment.checkout_url} target="_blank" rel="noreferrer" style={{ color: '#3b82f6', wordBreak: 'break-all' }}>{payment.checkout_url}</a></div>
             <div><strong>Created:</strong> {new Date(payment.created_at).toLocaleString()}</div>
@@ -262,7 +262,7 @@ export default function App() {
             Payment <code>{payment.id}</code> has been confirmed on-chain.
           </p>
           <p style={{ color: '#6b7280', fontSize: '0.875rem' }}>
-            Amount: <strong>${(payment.amount / 100).toFixed(2)} USDC</strong>
+            Amount: <strong>${payment.amount.toFixed(2)} USDC</strong>
           </p>
           <button
             onClick={handleReset}

--- a/products/stablecoin-gateway/apps/web/src/hooks/useDashboardData.ts
+++ b/products/stablecoin-gateway/apps/web/src/hooks/useDashboardData.ts
@@ -18,33 +18,35 @@ export interface DashboardTransaction {
   status: 'SUCCESS' | 'PENDING' | 'FAILED';
 }
 
-function formatCurrency(cents: number): string {
-  return '$' + (cents / 100).toLocaleString('en-US', {
+function formatCurrency(amount: number): string {
+  return '$' + amount.toLocaleString('en-US', {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   });
 }
 
 function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString('en-US', {
+  return new Date(iso).toLocaleString('en-US', {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
   });
 }
 
-function mapStatus(status: PaymentSession['status']): DashboardTransaction['status'] {
-  switch (status) {
-    case 'completed': return 'SUCCESS';
-    case 'pending':
-    case 'confirming': return 'PENDING';
+function mapStatus(status: string): DashboardTransaction['status'] {
+  switch (status.toUpperCase()) {
+    case 'COMPLETED': return 'SUCCESS';
+    case 'PENDING':
+    case 'CONFIRMING': return 'PENDING';
     default: return 'FAILED';
   }
 }
 
 function computeStats(sessions: PaymentSession[]) {
-  const completed = sessions.filter(s => s.status === 'completed');
-  const terminal = sessions.filter(s => s.status === 'completed' || s.status === 'failed');
+  const completed = sessions.filter(s => s.status.toUpperCase() === 'COMPLETED');
+  const terminal = sessions.filter(s => s.status.toUpperCase() === 'COMPLETED' || s.status.toUpperCase() === 'FAILED');
 
   const totalBalance = completed.reduce((sum, s) => sum + s.amount, 0);
   const volume = sessions.reduce((sum, s) => sum + s.amount, 0);

--- a/products/stablecoin-gateway/apps/web/src/lib/api-client.ts
+++ b/products/stablecoin-gateway/apps/web/src/lib/api-client.ts
@@ -491,6 +491,37 @@ export class ApiClient {
     return this.request<PaymentSession>(`/v1/payment-sessions/${id}`);
   }
 
+  /**
+   * Get payment session for checkout (public, no auth required)
+   */
+  async getCheckoutSession(id: string): Promise<PaymentSession> {
+    // Public endpoint - bypass auth header injection
+    const url = `${this.baseUrl}/v1/checkout/${id}`;
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      const error: ApiError = await response.json();
+      throw new ApiClientError(error.status, error.title, error.detail, error);
+    }
+
+    return response.json();
+  }
+
+  /**
+   * Dev-only: simulate payment completion (bypasses blockchain verification)
+   */
+  async simulatePayment(id: string): Promise<PaymentSession> {
+    const url = `${this.baseUrl}/v1/dev/simulate/${id}`;
+    const response = await fetch(url, { method: 'POST' });
+
+    if (!response.ok) {
+      const error: ApiError = await response.json();
+      throw new ApiClientError(error.status, error.title, error.detail, error);
+    }
+
+    return response.json();
+  }
+
   async updatePaymentSession(
     id: string,
     data: Partial<PaymentSession>

--- a/products/stablecoin-gateway/apps/web/src/lib/wagmi-config.ts
+++ b/products/stablecoin-gateway/apps/web/src/lib/wagmi-config.ts
@@ -19,7 +19,7 @@ const mainnetRpcUrl = import.meta.env.VITE_ALCHEMY_MAINNET_URL || 'https://eth.p
 export const config = createConfig({
   chains: [polygon, mainnet],
   connectors: [
-    injected({ target: 'metaMask' }),
+    injected(),
     walletConnect({
       projectId: walletConnectProjectId,
       metadata: {

--- a/products/stablecoin-gateway/apps/web/src/pages/dashboard/Invoices.tsx
+++ b/products/stablecoin-gateway/apps/web/src/pages/dashboard/Invoices.tsx
@@ -11,8 +11,8 @@ interface Invoice {
   date: string;
 }
 
-function formatCurrency(cents: number): string {
-  return '$' + (cents / 100).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+function formatCurrency(amount: number): string {
+  return '$' + amount.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 }
 
 export default function Invoices() {


### PR DESCRIPTION
## Summary

- **Amount bug**: Merchant demo sent 2500 (cents) but API expects dollars — checkout showed $2500.00 instead of $25.00. Dashboard/invoices had a second `/100` division, showing $0.25.
- **Status bug**: Dashboard compared lowercase statuses against the API's uppercase values (`COMPLETED` vs `completed`), marking all payments as FAILED.
- **StatusPage broken**: Used localStorage mock instead of real API — always showed "Payment Not Found" for real payments.
- **Dev simulation**: Added `POST /v1/dev/simulate/:id` endpoint and UI button to replace the non-functional "run simulate-payment.sh" instructions.

## Changes

**Bug fixes:**
- Merchant demo sends `amount: 25` (dollars), removed `/100` display hacks
- Dashboard `formatCurrency` no longer divides by 100
- Invoices `formatCurrency` no longer divides by 100
- Status mapping uses `.toUpperCase()` for case-insensitive comparison
- `computeStats` filters use case-insensitive status comparison
- Dashboard date column now includes time (hour:minute)
- Checkout URL corrected from `/checkout/` to `/pay/` to match web app routes

**New features:**
- Public checkout endpoint (`GET /v1/checkout/:id`) for unauthenticated payment lookup
- Dev-only simulate endpoint (`POST /v1/dev/simulate/:id`) bypasses blockchain verification
- `simulatePayment()` method on API client
- "Simulate Payment" button in checkout UI replaces shell script instructions
- `simulate-payment.sh` supports `--session-id` flag for existing payments
- StatusPage rewritten to fetch from real API with polling

## Test plan

- [x] End-to-end: create payment → checkout shows $25.00 → simulate → status page shows "Payment Complete"
- [x] Dev simulate endpoint: PENDING→COMPLETED, idempotent on already-completed, 404 on missing
- [x] Script `--session-id` flag works
- [x] CORS verified for checkout endpoint
- [x] TypeScript compiles clean (web + API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)