### PR TITLE
fix(stablecoin): address security issues in routes

### DIFF
--- a/notes/features/security-fixes.md
+++ b/notes/features/security-fixes.md
@@ -1,0 +1,31 @@
+# Security Fixes - stablecoin-gateway
+
+Branch: fix/stablecoin-gateway/security-fixes
+Base: feature/stablecoin-gateway/phase1-features
+
+## Fixes Applied
+
+1. **Payment Links Route Ordering** (payment-links.ts)
+   - Moved `GET /resolve/:shortCode` and `GET /:id/qr` BEFORE `GET /:id`
+   - Prevents Fastify from matching "resolve" as an `:id` parameter
+   - Removed duplicate route definitions from end of file
+
+2. **Admin Routes Validation** (admin.ts)
+   - Added Zod schemas: `merchantListQuerySchema` and `merchantPaymentsQuerySchema`
+   - Added `try-catch` blocks around both route handlers
+   - Replaced `any` type with `Prisma.UserWhereInput` and `Prisma.PaymentSessionWhereInput`
+   - Added `ZodError` handling with 400 responses
+   - Added logger import for error logging
+
+3. **Logout Token Ownership** (auth.ts)
+   - Already correctly implemented. The `where` clause at line 319 includes `userId`
+   - No changes needed
+
+4. **Notifications Duplicate validateBody** (notifications.ts)
+   - Added import of `validateBody` from `../../utils/validation.js`
+   - Removed local duplicate function definition (lines 42-44)
+
+5. **Gitignore .env**
+   - Already present in `apps/api/.gitignore` (line 11)
+   - Already present in root `.gitignore` (line 13)
+   - No changes needed

--- a/products/stablecoin-gateway/apps/api/src/routes/v1/notifications.ts
+++ b/products/stablecoin-gateway/apps/api/src/routes/v1/notifications.ts
@@ -23,6 +23,7 @@ import { z } from 'zod';
 import { AppError } from '../../types/index.js';
 import { EmailService } from '../../services/email.service.js';
 import { logger } from '../../utils/logger.js';
+import { validateBody } from '../../utils/validation.js';
 
 /**
  * Validation schema for updating notification preferences
@@ -35,13 +36,6 @@ const updatePreferencesSchema = z.object({
   emailOnPaymentFailed: z.boolean().optional(),
   sendCustomerReceipt: z.boolean().optional(),
 });
-
-/**
- * Validate request body against schema
- */
-function validateBody<T>(schema: z.ZodSchema<T>, data: unknown): T {
-  return schema.parse(data);
-}
 
 /**
  * Format notification preference response


### PR DESCRIPTION
## Summary
- **Payment links route ordering**: Moved `GET /resolve/:shortCode` and `GET /:id/qr` routes before the generic `GET /:id` route in `payment-links.ts` to prevent Fastify from matching "resolve" as an `:id` parameter
- **Admin routes validation**: Added Zod schemas (`merchantListQuerySchema`, `merchantPaymentsQuerySchema`) with proper limit/offset/status validation, wrapped handlers in try-catch, replaced `any` type with `Prisma.UserWhereInput` and `Prisma.PaymentSessionWhereInput`
- **Notifications duplicate code**: Removed local `validateBody` function and imported the shared one from `utils/validation.ts`

## Notes
- **Fix 3 (Logout token ownership)**: Already correctly implemented -- the `refreshToken.updateMany` where clause already includes `userId` alongside `tokenHash`
- **Fix 5 (.env in gitignore)**: Already present in both `apps/api/.gitignore` and root `.gitignore`

## Test plan
- [ ] Verify `GET /v1/payment-links/resolve/:shortCode` resolves correctly and is not intercepted by `/:id`
- [ ] Verify `GET /v1/payment-links/:id/qr` generates QR codes correctly
- [ ] Verify admin `/merchants` endpoint rejects invalid limit/offset values with 400
- [ ] Verify admin `/merchants/:id/payments` endpoint validates status enum values
- [ ] Verify notification preferences PATCH still works with imported `validateBody`