### PR TITLE
feat(company): add component registry and Motqen product plan

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -90,10 +90,26 @@ release/[product]/v[X.Y.Z]       # Releases
 - E2E: Playwright
 - All tests must pass before PR merge
 
+### Component Reuse (MANDATORY)
+
+**Before building ANY backend plugin, service, utility, frontend hook, component, or infrastructure config**, agents MUST:
+
+1. Read `.claude/COMPONENT-REGISTRY.md`
+2. Check the "I Need To..." quick reference table
+3. If a matching component exists: **copy and adapt it** — do NOT rebuild from scratch
+4. If you build something new that is generic (not domain-specific): **add it to the registry**
+
+This rule exists because ConnectSW has 25+ production-tested components across products. Rebuilding wastes time and introduces inconsistency.
+
+**Key registries:**
+- `.claude/COMPONENT-REGISTRY.md` — Reusable code components
+- `.claude/PORT-REGISTRY.md` — Port assignments
+
 ## Directory Structure
 
 ```
 /products/[name]/        # Individual products
+/packages/               # Shared cross-product packages (future)
 /docs/                   # Company documentation
 /notes/                  # CEO briefs, decisions
 /.claude/                # Agent definitions, workflows

--- a/.claude/COMPONENT-REGISTRY.md
+++ b/.claude/COMPONENT-REGISTRY.md
@@ -1,0 +1,571 @@
+# ConnectSW Component Registry
+
+> Before building anything, check this registry first. Reuse > rebuild.
+
+Last updated: 2026-02-02
+
+## How to Use This Registry
+
+- **Agents**: Read this file before starting any backend, frontend, or infrastructure work.
+- **When adding a new component**: Update this registry with source path, maturity, and dependencies.
+- **When a component is extracted to a shared package**: Update the source path to the package location.
+- **Paths are relative to**: `products/` directory root.
+
+---
+
+## "I Need To..." Quick Reference
+
+| I need...                  | Use these components                                                           |
+|----------------------------|-------------------------------------------------------------------------------|
+| Auth (JWT + API key)       | Auth Plugin + useAuth hook + TokenManager + ProtectedRoute                    |
+| API keys                   | Crypto Utils (hashApiKey, generateApiKey) + API Key routes + useApiKeys hook  |
+| Webhooks                   | Webhook Delivery Service + Circuit Breaker + Crypto Utils (signWebhookPayload)|
+| A data table               | TransactionsTable component (paginated, sortable)                             |
+| Billing / Stripe           | Stripe Plugin (invoiceforge)                                                  |
+| Real-time updates (SSE)    | SSE pattern (api-client.createEventSource) + TokenManager                     |
+| Rate limiting              | Redis Rate Limit Store + Redis Plugin                                         |
+| Encryption at rest         | Encryption Utils (AES-256-GCM)                                               |
+| Structured logging         | Logger + Observability Plugin                                                 |
+| Error handling             | Error Classes (invoiceforge) + AppError (stablecoin) + validation helpers     |
+| Pagination                 | Pagination Helper (invoiceforge) + listQuerySchemas (stablecoin)              |
+| Audit trail                | Audit Log Service (DB-backed + in-memory fallback)                            |
+| Email notifications        | Email Service (HTML templates, XSS-safe)                                      |
+| Dark/light theme           | useTheme hook + ThemeToggle component                                         |
+| Docker (production)        | Dockerfile (multi-stage, non-root, dumb-init) + docker-compose.yml            |
+| CI/CD                      | GitHub Actions quality gate workflow (test + lint + security + frontend)       |
+| E2E tests                  | Playwright Config + Auth Fixture (rate-limit-aware)                           |
+| DB connection              | Prisma Plugin (pool sizing, graceful shutdown)                                |
+| Redis connection           | Redis Plugin (TLS, graceful degradation, health monitoring)                   |
+| Request metrics            | Observability Plugin (p50/p95/p99, error rate, correlation IDs)               |
+| KPI display card           | StatCard component                                                            |
+| Navigation sidebar         | Sidebar component (role-aware, admin sections)                                |
+| Error boundary             | ErrorBoundary component (React class component with fallback UI)              |
+| Route protection           | ProtectedRoute component (token-based redirect)                               |
+
+---
+
+## Backend Components
+
+### Plugins (Fastify)
+
+#### Auth Plugin
+- **Source**: `stablecoin-gateway/apps/api/src/plugins/auth.ts`
+- **Maturity**: Production
+- **Reuse**: Copy as-is for JWT+API-key auth; adapt for different permission models
+- **Dependencies**: `fastify-plugin`, `@fastify/jwt`, Prisma Plugin, Crypto Utils (hashApiKey), Logger
+- **Used by**: stablecoin-gateway
+- **Description**: Dual authentication supporting JWT bearer tokens (user sessions) and HMAC-SHA256 API keys. Includes Redis-backed circuit breaker for token revocation checks (JTI blacklist), optional auth decorator, permission enforcement (read/write/refund), and admin role guard. Falls back gracefully when Redis is unavailable within a 30-second window.
+- **To reuse**: Copy the file. Adjust the permission enum in `requirePermission()` to match your domain. Ensure `@fastify/jwt` and Prisma Plugin are registered first. Requires `User` and `ApiKey` models in your Prisma schema.
+
+#### Redis Plugin
+- **Source**: `stablecoin-gateway/apps/api/src/plugins/redis.ts`
+- **Maturity**: Production
+- **Reuse**: Copy as-is
+- **Dependencies**: `fastify-plugin`, `ioredis`, Logger
+- **Used by**: stablecoin-gateway
+- **Description**: Redis connection management with TLS support, password auth, retry strategy with exponential backoff, graceful shutdown on app close, and health monitoring via ping. Decorates Fastify with `redis` (nullable -- graceful degradation if REDIS_URL not set). Configurable via REDIS_URL, REDIS_TLS, REDIS_TLS_REJECT_UNAUTHORIZED, REDIS_PASSWORD environment variables.
+- **To reuse**: Copy the file. No changes needed. Set REDIS_URL in your environment.
+
+#### Observability Plugin
+- **Source**: `stablecoin-gateway/apps/api/src/plugins/observability.ts`
+- **Maturity**: Production
+- **Reuse**: Copy as-is
+- **Dependencies**: `fastify-plugin`, `crypto` (Node built-in), Logger
+- **Used by**: stablecoin-gateway
+- **Description**: Request/response logging with correlation IDs (X-Request-ID), automatic performance timing, error rate monitoring, and in-memory metrics collection with p50/p95/p99 percentile calculation. Provides a protected `/internal/metrics` endpoint (requires INTERNAL_API_KEY with timing-safe comparison). Sanitizes PII from logs. Log level varies by status code (5xx=error, 4xx=warn, 2xx=info).
+- **To reuse**: Copy the file. Set INTERNAL_API_KEY for metrics access. Optionally replace in-memory metrics with Prometheus/StatsD.
+
+#### Prisma Plugin
+- **Source**: `stablecoin-gateway/apps/api/src/plugins/prisma.ts`
+- **Maturity**: Production
+- **Reuse**: Copy as-is
+- **Dependencies**: `fastify-plugin`, `@prisma/client`, Logger
+- **Used by**: stablecoin-gateway
+- **Description**: PrismaClient lifecycle management with configurable connection pool sizing (DATABASE_POOL_SIZE, DATABASE_POOL_TIMEOUT env vars), connection testing on startup, and graceful disconnect on app close. Decorates Fastify with `prisma`. Logs queries in development mode.
+- **To reuse**: Copy the file. Works with any Prisma schema.
+
+#### Stripe Plugin
+- **Source**: `invoiceforge/apps/api/src/plugins/stripe.ts`
+- **Maturity**: Solid
+- **Reuse**: Copy as-is
+- **Dependencies**: `fastify-plugin`, `stripe` npm package, app config
+- **Used by**: invoiceforge
+- **Description**: Initializes a Stripe client with the configured API version and decorates the Fastify instance with `stripe`. Simple and minimal -- a good starting point for any Stripe integration.
+- **To reuse**: Copy the file. Update the config import to use your project's config module or environment variable for `stripeSecretKey`.
+
+---
+
+### Services
+
+#### Webhook Circuit Breaker Service
+- **Source**: `stablecoin-gateway/apps/api/src/services/webhook-circuit-breaker.service.ts`
+- **Maturity**: Production
+- **Reuse**: Copy as-is; works with any Redis-like interface
+- **Dependencies**: Redis (via `RedisLike` interface -- not tightly coupled)
+- **Used by**: stablecoin-gateway (via Webhook Delivery Service)
+- **Description**: Tracks consecutive delivery failures per endpoint using Redis. After 10 failures (configurable), the circuit opens for 5 minutes, pausing deliveries. Uses a Lua script for atomic increment + circuit-open in a single Redis round-trip, preventing race conditions between concurrent workers. Falls back to non-atomic approach if Lua eval is unavailable. Automatically resets on success or after cooldown.
+- **To reuse**: Copy the file. The `RedisLike` interface accepts any object with `get/set/incr/del/expire/eval` methods. Adjust `CIRCUIT_THRESHOLD` and `CIRCUIT_RESET_MS` constants as needed.
+
+#### Audit Log Service
+- **Source**: `stablecoin-gateway/apps/api/src/services/audit-log.service.ts`
+- **Maturity**: Production
+- **Reuse**: Copy as-is; requires AuditLog Prisma model
+- **Dependencies**: `@prisma/client` (optional -- works in-memory without it)
+- **Used by**: stablecoin-gateway
+- **Description**: Fire-and-forget audit trail for security-critical actions (API key management, webhook changes, auth events, refunds). Persists to database via Prisma when available, falls back to in-memory ring buffer (10,000 entries). Automatically redacts sensitive fields (password, secret, token, key, authorization). Supports querying by actor, action, resourceType, and date range. The `record()` method never throws, ensuring audit failures do not block business operations.
+- **To reuse**: Copy the file. Add the AuditLog model to your Prisma schema (see Prisma Patterns section). Pass PrismaClient to the constructor for database persistence, or omit for in-memory-only.
+
+#### Email Service
+- **Source**: `stablecoin-gateway/apps/api/src/services/email.service.ts`
+- **Maturity**: Production
+- **Reuse**: Adapt (swap templates for your domain)
+- **Dependencies**: `@prisma/client` (for NotificationPreference model)
+- **Used by**: stablecoin-gateway
+- **Description**: Email notification system with professional HTML templates for customer receipts and merchant notifications. Manages per-user notification preferences (auto-created with defaults on first access). All user-controlled values are HTML-escaped (XSS prevention). Currently console-based for development; production path is SMTP via nodemailer or Resend/SendGrid.
+- **To reuse**: Copy the file. Replace the HTML templates in `generateReceiptHtml()` and `generateMerchantNotificationHtml()` with your domain-specific templates. The `sendEmail()` method is the integration point for your email provider.
+
+#### Webhook Delivery Service
+- **Source**: `stablecoin-gateway/apps/api/src/services/webhook-delivery.service.ts`
+- **Maturity**: Production
+- **Reuse**: Copy as-is for webhook delivery; adapt event types for your domain
+- **Dependencies**: `@prisma/client`, Logger, Webhook Circuit Breaker Service, Webhook Delivery Executor Service
+- **Used by**: stablecoin-gateway
+- **Description**: Full webhook delivery pipeline. Queues webhooks to all subscribed endpoints, processes the queue with concurrent workers using `SELECT FOR UPDATE SKIP LOCKED` (safe for multi-instance deployments), and delegates actual HTTP delivery to the executor service. Supports composite idempotency keys (endpointId + eventType + resourceId) to prevent duplicate deliveries. Retries with exponential backoff (1m, 5m, 15m, 1h, 2h) up to 5 attempts.
+- **To reuse**: Copy along with `webhook-circuit-breaker.service.ts` and `webhook-delivery-executor.service.ts`. Update the `WebhookEventType` union to match your domain events. Requires WebhookEndpoint and WebhookDelivery Prisma models.
+
+---
+
+### Utilities
+
+#### Crypto Utils
+- **Source**: `stablecoin-gateway/apps/api/src/utils/crypto.ts`
+- **Maturity**: Production
+- **Reuse**: Copy as-is
+- **Dependencies**: Node `crypto` built-in, `bcrypt`
+- **Used by**: stablecoin-gateway
+- **Description**: Cryptographic utility belt. Provides bcrypt password hashing (12 rounds), HMAC-SHA256 API key hashing (with API_KEY_HMAC_SECRET env var; falls back to plain SHA-256 in dev), API key generation with prefix (`sk_live_`/`sk_test_`), webhook secret generation (`whsec_` prefix), webhook payload signing with timestamp (timing-safe comparison), and ID generators for payment sessions (`ps_`) and refunds (`ref_`).
+- **To reuse**: Copy the file. Set API_KEY_HMAC_SECRET in production. Adjust prefixes and ID generators for your domain.
+
+#### Encryption Utils
+- **Source**: `stablecoin-gateway/apps/api/src/utils/encryption.ts`
+- **Maturity**: Production
+- **Reuse**: Copy as-is
+- **Dependencies**: Node `crypto` built-in, AppError type
+- **Used by**: stablecoin-gateway
+- **Description**: AES-256-GCM authenticated encryption for sensitive data at rest (webhook secrets, API credentials). Uses random 96-bit IVs per operation, 128-bit auth tags for tamper detection. Output format: `iv:authTag:ciphertext` (all base64). Requires initialization at startup with WEBHOOK_ENCRYPTION_KEY (exactly 64 hex chars / 32 bytes). Key is used directly (not hashed) for OpenSSL interoperability.
+- **To reuse**: Copy the file. Rename the env var from WEBHOOK_ENCRYPTION_KEY to a more generic name if desired. Generate key with `openssl rand -hex 32`.
+
+#### Logger
+- **Source**: `stablecoin-gateway/apps/api/src/utils/logger.ts`
+- **Maturity**: Production
+- **Reuse**: Copy as-is
+- **Dependencies**: None
+- **Used by**: stablecoin-gateway (all plugins and services)
+- **Description**: Structured logging utility with automatic sensitive field redaction. Patterns redacted: password, secret, token, authorization, apikey, api_key, private_key, creditcard, ssn, cookie, encryption_key, hmac, mnemonic, seed_phrase. Outputs JSON in production, human-readable format in development. Supports info/warn/error/debug levels (configurable via LOG_LEVEL env var). The error method accepts both Error objects and arbitrary data.
+- **To reuse**: Copy the file. No changes needed.
+
+#### Redis Rate Limit Store
+- **Source**: `stablecoin-gateway/apps/api/src/utils/redis-rate-limit-store.ts`
+- **Maturity**: Production
+- **Reuse**: Copy as-is
+- **Dependencies**: `ioredis`
+- **Used by**: stablecoin-gateway
+- **Description**: Distributed rate limiting store implementing the `@fastify/rate-limit` store interface. Uses Redis atomic INCR for token bucket counting with automatic TTL cleanup. Supports route-specific TTL via the `child()` method. Works across multiple server instances. The static `setRedis()` method allows setting the Redis instance once at startup.
+- **To reuse**: Copy the file. Call `RedisRateLimitStore.setRedis(redisInstance)` at startup, then pass the class to `@fastify/rate-limit` config.
+
+#### Validation Schemas (generic parts)
+- **Source**: `stablecoin-gateway/apps/api/src/utils/validation.ts`
+- **Maturity**: Production
+- **Reuse**: Pattern reference (extract the generic schemas)
+- **Dependencies**: `zod`
+- **Used by**: stablecoin-gateway
+- **Description**: Zod validation schemas. The reusable parts are: auth schemas (signup with strong password rules, login, logout, password reset), idempotency key schema (alphanumeric, 1-64 chars), pagination query schemas (limit/offset with coercion and bounds), metadata schema (key/value limits, 50 keys max, 16KB size limit), and the `validateBody`/`validateQuery` helper functions. Domain-specific schemas (payment, webhook, Ethereum address) should stay product-specific.
+- **To reuse**: Extract the auth, idempotency, pagination, and metadata schemas. Copy the `validateBody`/`validateQuery` helpers.
+
+#### Error Classes
+- **Source**: `invoiceforge/apps/api/src/lib/errors.ts`
+- **Maturity**: Production
+- **Reuse**: Copy as-is
+- **Dependencies**: None
+- **Used by**: invoiceforge
+- **Description**: Typed error hierarchy for consistent HTTP error responses. Base `AppError` with statusCode and code fields, plus convenience subclasses: NotFoundError (404), UnauthorizedError (401), ForbiddenError (403), BadRequestError (400), ConflictError (409), ValidationError (422, with field-level error map). All extend native Error for proper stack traces.
+- **To reuse**: Copy the file. Use with a Fastify error handler that maps `AppError.statusCode` to HTTP responses.
+
+#### Pagination Helper
+- **Source**: `invoiceforge/apps/api/src/lib/pagination.ts`
+- **Maturity**: Production
+- **Reuse**: Copy as-is
+- **Dependencies**: None
+- **Used by**: invoiceforge
+- **Description**: Standard pagination utilities. `parsePagination()` extracts and bounds-checks page/limit from query strings (defaults: page=1, limit=20, max limit=100). `paginatedResult()` wraps data arrays with pagination metadata (page, limit, total, totalPages, hasMore). Provides TypeScript interfaces: `PaginationParams`, `PaginatedResult<T>`.
+- **To reuse**: Copy the file. Works with any data type.
+
+---
+
+## Frontend Components
+
+### Libraries
+
+#### Token Manager
+- **Source**: `stablecoin-gateway/apps/web/src/lib/token-manager.ts`
+- **Maturity**: Production
+- **Reuse**: Copy as-is
+- **Dependencies**: None
+- **Used by**: stablecoin-gateway
+- **Description**: XSS-safe JWT storage using in-memory variables only -- tokens are never written to localStorage or sessionStorage. Provides setToken, getToken, clearToken, hasToken methods. Session persistence is handled via httpOnly refresh token cookies (server-side). Tokens are cleared on page refresh by design; the refresh token flow restores them.
+- **To reuse**: Copy the file. No changes needed.
+
+#### API Client Base
+- **Source**: `stablecoin-gateway/apps/web/src/lib/api-client.ts`
+- **Maturity**: Production
+- **Reuse**: Adapt (extract base class, remove product-specific endpoints)
+- **Dependencies**: `event-source-polyfill`, Token Manager
+- **Used by**: stablecoin-gateway
+- **Description**: Full-featured HTTP API client with automatic Bearer token injection from TokenManager, 401 response handling (clears token), mock mode for development/testing (localStorage-backed), SSE support via EventSourcePolyfill (tokens sent in Authorization header, not URL), and typed request/response methods. The `ApiClientError` class provides structured error information (status, title, detail).
+- **To reuse**: Copy the file. Remove product-specific methods (payment sessions, webhooks, etc.) and mock implementations. Keep the base `request<T>()` method, auth methods (login/logout/signup), token injection, and error handling as your foundation.
+
+---
+
+### Hooks
+
+#### useAuth
+- **Source**: `stablecoin-gateway/apps/web/src/hooks/useAuth.tsx`
+- **Maturity**: Production
+- **Reuse**: Copy as-is (depends on API Client)
+- **Dependencies**: API Client, Token Manager
+- **Used by**: stablecoin-gateway
+- **Description**: React hook providing authentication state (user, isAuthenticated, isLoading, error) and methods (login, logout). Stores minimal user info (id, email, role) in a module-level variable alongside the token for cross-render persistence without a /me endpoint. Checks for existing token on mount. Login stores token via TokenManager; logout clears everything.
+- **To reuse**: Copy the file. Update the import path for your API client. Adjust the User type fields if your auth response differs.
+
+#### useTheme
+- **Source**: `stablecoin-gateway/apps/web/src/hooks/useTheme.ts`
+- **Maturity**: Solid
+- **Reuse**: Copy as-is
+- **Dependencies**: None (uses localStorage + document.documentElement)
+- **Used by**: stablecoin-gateway
+- **Description**: Dark/light theme toggle with localStorage persistence. Adds/removes the `dark` class on `<html>` element (compatible with Tailwind dark mode). Returns `{ theme, toggleTheme }`. Storage key is configurable (currently `stableflow-theme`).
+- **To reuse**: Copy the file. Change the `STORAGE_KEY` constant to your product name.
+
+#### useApiKeys
+- **Source**: `stablecoin-gateway/apps/web/src/hooks/useApiKeys.ts`
+- **Maturity**: Solid
+- **Reuse**: Adapt (depends on API Client types)
+- **Dependencies**: API Client
+- **Used by**: stablecoin-gateway
+- **Description**: CRUD hook for API key management. Provides: apiKeys list, isLoading, error state, createdKey (holds the full key shown only once after creation), and methods: createApiKey, deleteApiKey, clearCreatedKey. Auto-loads on mount. Optimistic removal on delete.
+- **To reuse**: Copy the file. A good pattern reference for any CRUD resource hook.
+
+#### useWebhooks
+- **Source**: `stablecoin-gateway/apps/web/src/hooks/useWebhooks.ts`
+- **Maturity**: Solid
+- **Reuse**: Adapt (depends on API Client types)
+- **Dependencies**: API Client
+- **Used by**: stablecoin-gateway
+- **Description**: Full CRUD hook for webhook management. Provides: webhooks list, isLoading, error state, createdWebhook (with secret), rotatedSecret, and methods: createWebhook, updateWebhook, deleteWebhook, rotateSecret, clearCreatedWebhook, clearRotatedSecret. Exports `WEBHOOK_EVENTS` constant and `WebhookEvent` type. Auto-loads on mount.
+- **To reuse**: Copy the file. Update event types for your domain.
+
+---
+
+### UI Components
+
+#### ErrorBoundary
+- **Source**: `stablecoin-gateway/apps/web/src/components/ErrorBoundary.tsx`
+- **Maturity**: Production
+- **Reuse**: Copy as-is
+- **Dependencies**: React
+- **Used by**: stablecoin-gateway
+- **Description**: React class-based error boundary with a styled fallback UI. Shows an error icon, friendly message, expandable technical details, and a "Go to Homepage" button. Uses Tailwind CSS for styling. Logs errors to console via `componentDidCatch`.
+- **To reuse**: Copy the file. Wrap your app's root or page layouts with `<ErrorBoundary>`.
+
+#### ProtectedRoute
+- **Source**: `stablecoin-gateway/apps/web/src/components/ProtectedRoute.tsx`
+- **Maturity**: Production
+- **Reuse**: Copy as-is
+- **Dependencies**: `react-router-dom`, Token Manager
+- **Used by**: stablecoin-gateway
+- **Description**: Route guard component for React Router. Checks `TokenManager.hasToken()` and redirects to `/login` if unauthenticated. Uses `<Navigate replace />` for clean history. Renders `<Outlet />` for nested routes.
+- **To reuse**: Copy the file. Adjust the redirect path if your login route differs.
+
+#### StatCard
+- **Source**: `stablecoin-gateway/apps/web/src/components/dashboard/StatCard.tsx`
+- **Maturity**: Production
+- **Reuse**: Copy as-is
+- **Dependencies**: Tailwind CSS (uses semantic color tokens: card-bg, card-border, text-primary, text-secondary, accent-green)
+- **Used by**: stablecoin-gateway
+- **Description**: KPI display card with title, large value, optional trend indicator (with upward arrow icon), and optional subtitle. Clean, minimal design suitable for dashboard overview sections.
+- **To reuse**: Copy the file. Ensure your Tailwind config includes the semantic color tokens, or replace with standard Tailwind colors.
+
+#### Sidebar
+- **Source**: `stablecoin-gateway/apps/web/src/components/dashboard/Sidebar.tsx`
+- **Maturity**: Production
+- **Reuse**: Pattern reference (navigation structure is product-specific)
+- **Dependencies**: `react-router-dom`, useAuth hook, ThemeToggle, Tailwind CSS
+- **Used by**: stablecoin-gateway
+- **Description**: Fixed-position navigation sidebar with role-aware sections (main nav, developer tools, admin-only section, settings). Uses React Router's `NavLink` with active state styling. Includes ThemeToggle at the bottom. Each nav item has an SVG icon, label, and route path.
+- **To reuse**: Copy as a pattern. Replace the nav items array with your product's routes and icons. The `NavItem` component and role-based section rendering are the reusable parts.
+
+#### ThemeToggle
+- **Source**: `stablecoin-gateway/apps/web/src/components/dashboard/ThemeToggle.tsx`
+- **Maturity**: Solid
+- **Reuse**: Copy as-is (requires useTheme hook)
+- **Dependencies**: useTheme hook
+- **Used by**: stablecoin-gateway
+- **Description**: Toggle button for dark/light mode with sun/moon icons. Pairs with the useTheme hook for state management.
+- **To reuse**: Copy alongside useTheme hook.
+
+#### TransactionsTable
+- **Source**: `stablecoin-gateway/apps/web/src/components/dashboard/TransactionsTable.tsx`
+- **Maturity**: Production
+- **Reuse**: Pattern reference (column definitions are product-specific)
+- **Dependencies**: Tailwind CSS
+- **Used by**: stablecoin-gateway
+- **Description**: Paginated, sortable data table for displaying transaction records. Includes status badges, amount formatting, date formatting, and responsive layout. A good pattern for building any data table component.
+- **To reuse**: Use as a pattern reference. Extract the table skeleton (header, rows, pagination controls) and customize columns for your data model.
+
+---
+
+## Infrastructure
+
+### Docker
+
+#### Multi-Stage Dockerfile (API)
+- **Source**: `stablecoin-gateway/apps/api/Dockerfile`
+- **Maturity**: Production
+- **Reuse**: Copy as-is; adjust paths and port
+- **Description**: Two-stage build (builder + runner). Builder installs deps, generates Prisma client, and compiles TypeScript. Runner uses Alpine, installs `dumb-init` for proper PID 1 signal handling, creates a non-root `nodejs` user (UID 1001), copies only built artifacts. Includes a health check on `/health`. Exposes port 5001.
+- **To reuse**: Copy and update: port number (EXPOSE), health check URL, source copy paths. The dumb-init + non-root user pattern is production-ready.
+
+#### Docker Compose (Full Stack)
+- **Source**: `stablecoin-gateway/docker-compose.yml`
+- **Maturity**: Production
+- **Reuse**: Adapt for your service topology
+- **Description**: PostgreSQL 15 Alpine + Redis 7 Alpine + API + Web frontend. Features: health checks on all services, volume persistence, environment variable injection with required-secret validation (`${VAR:?error message}`), localhost-only port binding for databases (`127.0.0.1:port:port`), automatic Prisma migration on API startup. Optional merchant-demo service behind a Docker profile.
+- **To reuse**: Copy and update service names, ports, and environment variables for your product.
+
+---
+
+### CI/CD
+
+#### GitHub Actions Quality Gate Workflow
+- **Source**: `.github/workflows/test-stablecoin-gateway.yml`
+- **Maturity**: Production
+- **Reuse**: Copy and adapt per product
+- **Description**: Four parallel jobs (test, lint, security, test-frontend) with a final quality-gate job that fails if any predecessor failed. Test job runs against a real PostgreSQL 15 service container. Lint job runs ESLint + TypeScript type checking. Security job runs `npm audit`. Frontend job runs Jest tests. Uses Node 20, npm caching, and path-based triggering (only runs when product files change).
+- **To reuse**: Copy the file. Update: working-directory paths, path triggers, database name, and cache-dependency-path.
+
+---
+
+### Playwright (E2E Testing)
+
+#### Playwright Config
+- **Source**: `stablecoin-gateway/apps/web/playwright.config.ts`
+- **Maturity**: Production
+- **Reuse**: Copy as-is; adjust baseURL and webServer command
+- **Description**: Single-worker sequential execution (rate-limit-safe), Chromium only, HTML reporter, trace on first retry, CI-aware retries (2 in CI, 0 locally). Configures webServer to auto-start `npm run dev` with 120s startup timeout and existing-server reuse in local dev.
+- **To reuse**: Copy and update `baseURL` and `webServer.command` for your product.
+
+#### Auth Fixture
+- **Source**: `stablecoin-gateway/apps/web/e2e/fixtures/auth.fixture.ts`
+- **Maturity**: Production
+- **Reuse**: Copy as-is; adjust API_URL and user creation
+- **Description**: Playwright test fixture providing authenticated pages without consuming rate-limit slots. Creates unique users via API (one per worker, reused across tests). Authenticates browser pages by intercepting login API calls with `page.route()` and returning pre-fetched tokens -- zero API calls for browser auth. Includes helpers: `navigateTo()` for client-side routing (avoids token-clearing full reloads), `loginAsAdmin()` with cached admin tokens, `createUserWithApiKey()` for payment tests, and `loginViaUI()` for testing the login flow itself.
+- **To reuse**: Copy the file. Update `API_URL`, `TEST_PASSWORD`, and the user creation flow to match your auth endpoints.
+
+---
+
+### Prisma Patterns
+
+These Prisma model patterns are ready to copy into new product schemas.
+
+#### User Model
+```prisma
+model User {
+  id           String   @id @default(cuid())
+  email        String   @unique
+  passwordHash String   @map("password_hash")
+  role         Role     @default(MERCHANT)
+  createdAt    DateTime @default(now()) @map("created_at")
+  updatedAt    DateTime @updatedAt @map("updated_at")
+  @@map("users")
+}
+```
+- **Source**: `stablecoin-gateway/apps/api/prisma/schema.prisma`
+
+#### ApiKey Model
+```prisma
+model ApiKey {
+  id          String    @id @default(cuid())
+  userId      String    @map("user_id")
+  name        String
+  keyHash     String    @unique @map("key_hash")
+  keyPrefix   String    @map("key_prefix")
+  permissions Json      @default("{\"read\":true,\"write\":true,\"refund\":false}")
+  lastUsedAt  DateTime? @map("last_used_at")
+  createdAt   DateTime  @default(now()) @map("created_at")
+  user        User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  @@index([userId])
+  @@index([keyHash])
+  @@map("api_keys")
+}
+```
+- **Source**: `stablecoin-gateway/apps/api/prisma/schema.prisma`
+
+#### WebhookEndpoint Model
+```prisma
+model WebhookEndpoint {
+  id          String   @id @default(cuid())
+  userId      String   @map("user_id")
+  url         String
+  secret      String
+  events      String[]
+  enabled     Boolean  @default(true)
+  description String?
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
+  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  @@index([userId])
+  @@map("webhook_endpoints")
+}
+```
+- **Source**: `stablecoin-gateway/apps/api/prisma/schema.prisma`
+
+#### WebhookDelivery Model
+```prisma
+model WebhookDelivery {
+  id            String        @id @default(cuid())
+  endpointId    String        @map("endpoint_id")
+  eventType     String        @map("event_type")
+  payload       Json
+  resourceId    String        @map("resource_id")
+  attempts      Int           @default(0)
+  status        WebhookStatus @default(PENDING)
+  lastAttemptAt DateTime?     @map("last_attempt_at")
+  nextAttemptAt DateTime?     @map("next_attempt_at")
+  succeededAt   DateTime?     @map("succeeded_at")
+  responseCode  Int?          @map("response_code")
+  responseBody  String?       @map("response_body") @db.Text
+  errorMessage  String?       @map("error_message") @db.Text
+  endpoint      WebhookEndpoint @relation(fields: [endpointId], references: [id], onDelete: Cascade)
+  @@unique([endpointId, eventType, resourceId], name: "webhook_delivery_idempotency")
+  @@index([endpointId, status])
+  @@index([status, nextAttemptAt])
+  @@map("webhook_deliveries")
+}
+```
+- **Source**: `stablecoin-gateway/apps/api/prisma/schema.prisma`
+
+#### AuditLog Model
+```prisma
+model AuditLog {
+  id           String   @id @default(cuid())
+  actor        String
+  action       String
+  resourceType String   @map("resource_type")
+  resourceId   String   @map("resource_id")
+  details      Json?
+  ip           String?
+  userAgent    String?  @map("user_agent")
+  timestamp    DateTime @default(now())
+  @@index([actor])
+  @@index([action])
+  @@index([resourceType])
+  @@index([timestamp])
+  @@map("audit_logs")
+}
+```
+- **Source**: `stablecoin-gateway/apps/api/prisma/schema.prisma`
+
+---
+
+## Product Inventory
+
+Components in this registry are sourced from these products:
+
+| Product              | Status     | Backend | Frontend | Has Docker | Has CI |
+|----------------------|------------|---------|----------|------------|--------|
+| stablecoin-gateway   | Production | Yes     | Yes      | Yes        | Yes    |
+| invoiceforge         | Production | Yes     | Yes      | Yes        | Yes    |
+| deal-flow-platform   | Active     | Yes     | Yes      | No         | No     |
+| meetingmind          | Active     | --      | --       | --         | --     |
+| motqen               | Active     | --      | --       | --         | --     |
+| shipwright            | New        | --      | --       | --         | --     |
+
+---
+
+## Shared Package Extraction Roadmap
+
+Plan for extracting reusable components into `@connectsw/*` packages in the monorepo root `packages/` directory.
+
+### Phase 1: `packages/backend-core/`
+**Priority**: High -- most components are already production-tested.
+
+Contents:
+- `plugins/auth.ts` -- Auth Plugin (parameterize permission model)
+- `plugins/redis.ts` -- Redis Plugin (copy as-is)
+- `plugins/prisma.ts` -- Prisma Plugin (copy as-is)
+- `plugins/observability.ts` -- Observability Plugin (copy as-is)
+- `utils/crypto.ts` -- Crypto Utils (copy as-is)
+- `utils/encryption.ts` -- Encryption Utils (generalize env var name)
+- `utils/logger.ts` -- Logger (copy as-is)
+- `utils/redis-rate-limit-store.ts` -- Rate Limit Store (copy as-is)
+- `utils/validation.ts` -- Generic schemas only (auth, pagination, idempotency, metadata)
+- `lib/errors.ts` -- Error Classes from invoiceforge
+- `lib/pagination.ts` -- Pagination Helper from invoiceforge
+- `services/audit-log.service.ts` -- Audit Log Service (copy as-is)
+- `services/webhook-circuit-breaker.service.ts` -- Circuit Breaker (copy as-is)
+
+**Migration path**: Publish as `@connectsw/backend-core`. Update imports in stablecoin-gateway and invoiceforge. New products import from the package.
+
+### Phase 2: `packages/frontend-core/`
+**Priority**: High -- needed by every web product.
+
+Contents:
+- `lib/token-manager.ts` -- Token Manager (copy as-is)
+- `lib/api-client-base.ts` -- Extract the base request method, auth, error handling from stablecoin-gateway's API client
+- `hooks/useAuth.tsx` -- useAuth hook (parameterize API client)
+- `hooks/useTheme.ts` -- useTheme hook (parameterize storage key)
+
+**Migration path**: Publish as `@connectsw/frontend-core`. Products extend the base API client with their domain-specific methods.
+
+### Phase 3: `packages/ui/`
+**Priority**: Medium -- needed as product count grows.
+
+Contents:
+- `ErrorBoundary.tsx` -- Error Boundary (copy as-is)
+- `ProtectedRoute.tsx` -- Protected Route (copy as-is)
+- `StatCard.tsx` -- KPI Card (copy as-is)
+- `ThemeToggle.tsx` -- Theme Toggle (copy as-is)
+- `Sidebar.tsx` -- Base Sidebar (extract NavItem + section pattern)
+- `DataTable.tsx` -- Extract from TransactionsTable (generalize columns)
+- Badge, Button, Card, Input from invoiceforge (when created as shared components)
+
+**Migration path**: Publish as `@connectsw/ui`. Styled with Tailwind CSS semantic tokens. Products import and compose.
+
+### Phase 4: `packages/infrastructure/`
+**Priority**: Low -- templates are infrequently created.
+
+Contents:
+- `docker/Dockerfile.api.template` -- Multi-stage API Dockerfile template
+- `docker/docker-compose.base.yml` -- Base compose with Postgres + Redis
+- `ci/quality-gate.yml` -- GitHub Actions quality gate template
+- `prisma/base-models.prisma` -- User, ApiKey, WebhookEndpoint, AuditLog base models
+- `playwright/auth-fixture.ts` -- E2E auth fixture template
+- `playwright/playwright.config.template.ts` -- Base Playwright config
+
+**Migration path**: Keep as templates that are copied and customized per product. Not published as an npm package.
+
+---
+
+## Conventions
+
+### Naming
+- Fastify plugins: `[name].ts` in `src/plugins/`, registered via `fastify-plugin` with a `name` property
+- Services: `[name].service.ts` in `src/services/`, class-based with constructor injection
+- Utilities: `[name].ts` in `src/utils/`, pure functions exported directly
+- React hooks: `use[Name].ts` in `src/hooks/`
+- React components: `[Name].tsx` in `src/components/` or `src/components/[section]/`
+
+### Maturity Levels
+- **Production**: Battle-tested, fully covered by tests, used in deployed products
+- **Solid**: Well-tested, used in development, ready for production with minor review
+- **Prototype**: Functional but needs hardening before production use

--- a/.claude/orchestrator/orchestrator-enhanced.md
+++ b/.claude/orchestrator/orchestrator-enhanced.md
@@ -8,6 +8,12 @@ For detailed execution instructions, see: `.claude/orchestrator/claude-code-exec
 
 ## Available Systems
 
+### 0. Component Registry (CHECK FIRST)
+- **Registry**: `.claude/COMPONENT-REGISTRY.md` — All reusable code across products
+- **Rule**: Before assigning ANY build task, check if a reusable component exists
+- **Quick lookup**: Use the "I Need To..." table to find existing components
+- **When agents build something generic**: They MUST add it to the registry
+
 ### 1. Task Graph Engine
 - **Templates**: `.claude/workflows/templates/` (new-product, new-feature, bug-fix, release)
 - **Instantiate**: `.claude/scripts/instantiate-task-graph.sh`
@@ -31,12 +37,13 @@ For detailed execution instructions, see: `.claude/orchestrator/claude-code-exec
 
 ## Core Principles
 
-1. **CEO talks to you, you talk to agents** - Never ask CEO to invoke another agent directly
-2. **Use Task Graph Engine** - Load workflow templates, let engine manage execution
-3. **Agents use Memory** - Always instruct agents to read their memory first
-4. **AgentMessage Protocol** - Expect structured responses from agents
-5. **Checkpoint at milestones** - Pause for CEO approval at defined points
-6. **Retry 3x then escalate** - Don't get stuck, but don't give up too easily
+1. **Reuse before rebuild** - Check `.claude/COMPONENT-REGISTRY.md` before building anything. Copy proven code, don't reinvent it.
+2. **CEO talks to you, you talk to agents** - Never ask CEO to invoke another agent directly
+3. **Use Task Graph Engine** - Load workflow templates, let engine manage execution
+4. **Agents use Memory** - Always instruct agents to read their memory first
+5. **AgentMessage Protocol** - Expect structured responses from agents
+6. **Checkpoint at milestones** - Pause for CEO approval at defined points
+7. **Retry 3x then escalate** - Don't get stuck, but don't give up too easily
 
 ## Your Responsibilities
 
@@ -149,7 +156,15 @@ C. INVOKE AGENTS IN PARALLEL
      subagent_type: "general-purpose",
      prompt: "You are the [Agent Name] for ConnectSW.
 
-     ## FIRST: Read Your Memory
+     ## FIRST: Check the Component Registry
+     Read: .claude/COMPONENT-REGISTRY.md
+
+     Before building anything, check if a reusable component already exists.
+     Use the 'I Need To...' table to find matching components.
+     If one exists: copy it from the source product and adapt it.
+     If you build something new and generic: add it to the registry.
+
+     ## SECOND: Read Your Memory
      Read: .claude/memory/agent-experiences/[agent].json
      Read: .claude/memory/company-knowledge.json
 

--- a/notes/features/ai-testing-automation-market-research.md
+++ b/notes/features/ai-testing-automation-market-research.md
@@ -1,0 +1,366 @@
+# AI-Powered Testing Automation SaaS - Market Research Report
+
+**Date:** February 2, 2026
+**Purpose:** Comprehensive market analysis for AI-powered testing automation SaaS opportunity
+
+---
+
+## 1. Market Size & Growth
+
+### Global Software Testing Market
+| Metric | Value |
+|--------|-------|
+| 2025 Market Size | $54.68 billion |
+| 2033 Forecast | $126.91 billion |
+| CAGR | 11.33% (2026-2033) |
+| North America Share | 39% (2025) |
+| Fastest Growing Region | Asia Pacific (13.08% CAGR) |
+
+### Test Automation Market (Subset)
+| Metric | Value |
+|--------|-------|
+| 2025 Market Size | $19.97 billion |
+| 2031 Forecast | $51.36 billion |
+| CAGR | 17.05% |
+| Share of Total Testing | 53% of revenue (2025) |
+
+### AI-Enabled Testing Market (Subset)
+| Metric | Value |
+|--------|-------|
+| 2024 Market Size | $856.7 million |
+| 2025 Market Size | $1.01 billion |
+| 2032 Forecast | $3.82 billion |
+| CAGR | 20.9% |
+
+### AI Test Coverage Analytics
+| Metric | Value |
+|--------|-------|
+| 2024 Market Size | $1.34 billion |
+| 2025 Market Size | $1.67 billion |
+| 2029 Forecast | $3.97 billion |
+| CAGR | 24.6% |
+
+**Key Insight:** The AI-enabled testing segment is growing at 2-3x the rate of the overall testing market, signaling massive opportunity for AI-native entrants.
+
+---
+
+## 2. Competitive Landscape
+
+### Tier 1: Enterprise Leaders
+
+#### Tricentis (including Testim)
+- **Position:** Gartner Magic Quadrant Leader
+- **Focus:** Enterprise testing (SAP, mainframes, complex apps)
+- **AI Features:** Agentic test automation, AI smart locators, Testim Copilot, natural language test creation, self-healing selectors
+- **Target:** Fortune 500 companies
+- **Pricing:** Enterprise custom pricing
+- **Strengths:** Deep enterprise integrations, acquired Testim for SaaS/AI capabilities
+- **Weaknesses:** High cost, complex for small teams
+
+#### Katalon
+- **Position:** Gartner Magic Quadrant Visionary (2025)
+- **Focus:** Comprehensive web, mobile, API, desktop testing
+- **AI Features:** TrueTest (AI-recorded user interactions), AI-generated test scripts
+- **Pricing:**
+  - Free tier (forever free with core features)
+  - Premium: $175/month per license
+  - Enterprise: Custom pricing
+  - 2026 promo: 50% off first 3 licenses ($1,000 each)
+- **Strengths:** Free tier, broad platform coverage, growing AI features
+- **Weaknesses:** Advanced features locked behind paid tiers, cost concerns for small businesses
+
+#### BrowserStack
+- **Position:** Market leader in cloud testing infrastructure
+- **Focus:** Real device/browser testing (30,000+ devices)
+- **AI Features:** AI agents for test creation, visual validation
+- **Pricing:**
+  - Manual testing: $25-39/user/month
+  - Automated testing: $129-199/month (desktop/mobile)
+  - 5-device automation plan: ~$1,125/month
+  - Enterprise: Custom (average $32,433/year, up to $605,318)
+- **Strengths:** Massive device coverage, enterprise trust, mature platform
+- **Weaknesses:** Expensive at scale, pricing complexity
+
+### Tier 2: AI-Native Challengers
+
+#### LambdaTest / TestMu AI (KaneAI)
+- **Position:** Gartner Challenger (November 2025)
+- **Focus:** AI-native testing cloud with KaneAI agent
+- **AI Features:** KaneAI - natural language test generation, intelligent test planner, 2-way editing (NL + code), auto bug detection and healing, Slack/Jira/GitHub integration
+- **Pricing:** Competes aggressively on price vs BrowserStack
+- **Strengths:** Rapid AI innovation, cost-effective, KaneAI is genuinely differentiated
+- **Weaknesses:** Newer platform, less enterprise maturity than BrowserStack
+
+#### mabl
+- **Position:** Leading AI-native test automation platform
+- **Focus:** Low-code, AI-driven testing for Agile/DevOps
+- **AI Features:** Test Creation Agent, GenAI Assertions, Auto Test Failure Analysis, MCP Server integration
+- **Pricing:**
+  - 14-day free trial
+  - Credits-based model (500 credits/month for cloud runs)
+  - Custom pricing (enterprise-focused)
+- **Customers:** Workday, Vivid Seats, JetBlue
+- **Strengths:** Agentic tester concept, strong CI/CD integration, trusted enterprise customers
+- **Weaknesses:** No public pricing, potentially high cost
+
+#### QA Wolf
+- **Position:** Managed E2E testing service
+- **Focus:** Gets teams to 80% E2E test coverage in 4 months
+- **Model:** Service + platform hybrid (they build and maintain your tests)
+- **Technology:** Uses Playwright (web) and Appium (mobile) - code is yours to own
+- **Pricing:** Pay-per-test-under-management (custom quotes)
+- **Strengths:** Zero vendor lock-in (Playwright code), zero flake guarantee, 24/7 test maintenance
+- **Weaknesses:** Service model doesn't scale for all, reports of 800% renewal increases, slower ramp than promised
+- **Key Differentiator:** Only player offering managed QA as a service with open-source code ownership
+
+#### Momentic
+- **Position:** Emerging AI-native startup (Y Combinator)
+- **Funding:** $15M Series A (Nov 2025) + $3.7M seed
+- **Focus:** Natural language test authoring with AI agents
+- **AI Features:** NL test creation, self-healing via intent-based locators (no CSS/XPath), visual diffing, production monitoring
+- **Key Difference:** Does NOT generate Playwright/Selenium code; AI interprets NL steps at runtime
+- **Customers:** Notion, Xero, Bilt, Webflow, Retool (2,600+ users)
+- **Pricing:** Not publicly listed (custom plans)
+- **Strengths:** Truly AI-native architecture, low maintenance, strong early traction
+- **Weaknesses:** Founded 2023 (young), Chromium-only (Safari/Firefox on roadmap), proprietary execution
+
+#### Virtuoso QA
+- **Position:** AI-powered, no-code test automation platform
+- **Focus:** Natural language test authoring + self-healing automation
+- **Pricing:** Volume-based, custom (free trial available)
+- **Strengths:** Natural language authoring, self-maintaining test suites
+- **Weaknesses:** Enterprise-focused pricing may exclude SMBs
+
+### Tier 3: Specialized Players
+
+#### Applitools
+- **Focus:** AI-powered visual testing (Visual AI)
+- **Strengths:** Best-in-class visual regression testing, Ultrafast Grid
+- **Pricing:** Free trial, enterprise plans (unlimited tests/users)
+- **Niche:** Visual testing only - needs companion tools for functional testing
+
+#### Functionize
+- **Focus:** AI-powered end-to-end testing with natural language
+- **Strengths:** NLP test creation, autonomous maintenance, real-time debugging
+- **Pricing:** Contact-based only
+
+#### Checkly
+- **Focus:** Playwright-based monitoring and synthetic testing
+- **Pricing:**
+  - Hobby (Free): 1K browser runs, 10K API runs
+  - Team: Custom
+  - Enterprise: Custom
+- **Strengths:** Monitoring as Code, native Playwright integration, developer-friendly
+- **Differentiator:** Bridges testing and production monitoring
+
+#### BlinqIO
+- **Focus:** Cucumber-based AI virtual testers
+- **Differentiator:** Uses BDD (Cucumber) as the "test speak" language for AI
+
+### Tier 4: Newer/Emerging Startups
+
+| Company | Focus | Notable |
+|---------|-------|---------|
+| Antithesis | Simulation testing | $105M Series A from Jane Street |
+| Autify | AI-powered no-code testing | Growing in Japanese/Asian markets |
+| Bug0 | Open-source AI testing alternatives | Content/community play |
+| Testsigma | GenAI codeless test automation | NLP approach, multi-platform |
+| ACCELQ | Codeless AI test automation | Enterprise continuous testing |
+
+---
+
+## 3. Pricing Models Summary
+
+| Model | Used By | Pros | Cons |
+|-------|---------|------|------|
+| **Per user/seat** | BrowserStack, Katalon | Predictable, easy to understand | Penalizes growing teams |
+| **Per test under management** | QA Wolf | Aligned with value delivered | Can lead to scope creep, surprising renewals |
+| **Credits/execution-based** | mabl, BrowserStack (parallel) | Pay for what you use | Hard to predict costs, can spike |
+| **Custom/enterprise** | Tricentis, Virtuoso, Functionize | Flexible for large orgs | No transparency, long sales cycles |
+| **Freemium + tiers** | Katalon, Checkly | Low barrier to entry | Free tier may limit growth features |
+| **Per parallel session** | BrowserStack, LambdaTest | Scales with CI/CD needs | Expensive for high concurrency |
+
+**Industry Average:** Basic automated testing software averages $44/month. Enterprise contracts range from $15K to $600K+ annually.
+
+---
+
+## 4. Customer Pain Points & Market Gaps
+
+### Top Customer Complaints
+
+1. **Test Maintenance (60-80% of effort)** - UI changes break tests constantly, consuming most of automation effort. Self-healing is promised but inconsistent.
+
+2. **Flaky Tests / CI Failures** - Tests pass locally but fail in CI pipelines. Zero-flake guarantees (like QA Wolf's) are rare and valuable.
+
+3. **Test Creation Bottlenecks** - Writing tests is still slow. Natural language tools help but have accuracy/hallucination issues.
+
+4. **Pricing Opacity** - Most tools require "contact sales" for pricing. Developers and small teams are frustrated by the lack of transparent pricing.
+
+5. **Vendor Lock-in** - Proprietary test formats (Momentic, Testim) lock teams into a platform. Open-source code ownership (QA Wolf's Playwright approach) is a strong differentiator.
+
+6. **Integration Friction** - AI tools that don't plug cleanly into existing CI/CD pipelines, version control, and communication tools lose value.
+
+7. **Renewal Pricing Surprises** - Reports of significant price increases at renewal (QA Wolf 800% increase cited).
+
+8. **Skills Gap** - 37% of tech firms report software development skills gaps. 38% of organizations lack training for cloud-native testing.
+
+9. **Limited Cross-Browser Support** - Many AI-native tools (e.g., Momentic) only support Chromium, leaving Safari/Firefox gaps.
+
+10. **Hallucination in AI-Generated Tests** - LLMs generate tests from training data, not actual application structure, leading to unreliable test generation without proper context.
+
+### Underserved Market Segments
+
+1. **SMBs and Startups** - Most AI testing tools target enterprise. Small teams need affordable, self-serve solutions.
+
+2. **Developer-First Experience** - Tools built for QA teams, not developers. Gap for testing tools that feel like dev tools (CLI-first, Git-native, IDE integration).
+
+3. **Open-Source + AI Hybrid** - No dominant solution combining open-source Playwright with reliable AI assistance in a SaaS wrapper.
+
+4. **Testing-to-Monitoring Bridge** - Few tools seamlessly convert E2E tests into production monitors (Checkly and Momentic are early movers here).
+
+5. **Pay-Per-Use, Transparent Pricing** - Cloud-native, usage-based pricing for small/mid teams is underserved.
+
+6. **Real User Behavior-Driven Testing** - Test suites that update automatically based on production user behavior patterns.
+
+---
+
+## 5. Technology Trends: AI + Playwright
+
+### Playwright's Dominance
+Playwright has become the testing framework of choice for modern web applications. Key advantages:
+- Fast, reliable, developer-friendly
+- Cross-browser support (Chromium, Firefox, WebKit)
+- Native auto-wait mechanisms
+- Parallel test execution
+- Microsoft-backed, active development
+
+### Official Playwright + AI: Test Agents & MCP
+- **Playwright Test Agents** run on Model Context Protocol (MCP), connecting AI models to Playwright
+- **Playwright MCP Server** uses the browser's accessibility tree (not screenshots) for structured interaction
+- Integrates with CI/CD pipelines, Claude Desktop, and Cursor IDE
+- Open-source, available on GitHub (Microsoft)
+
+### Key Open-Source AI + Playwright Projects
+
+**Test Generation from Natural Language:**
+| Project | Description |
+|---------|-------------|
+| PlaywrightGPT | GPT-4 generates Playwright code from natural language |
+| Playwright AI (CLI) | CLI turns prompts into Playwright tests using GPT-4/Claude |
+| Playwright Copilot | VS Code extension for BDD-to-Playwright via AI |
+| playwright-ai (andytyler) | Minimal ai() helper for Playwright powered by Anthropic |
+| Promptwright | Prompts to Playwright/Cypress/Selenium scripts |
+
+**AI Locators & Smart Selectors:**
+| Project | Description |
+|---------|-------------|
+| AI Locators | Natural-language locators replacing CSS/XPath |
+| AgentQL | AI query language integrated with Playwright |
+| Auto Playwright | ChatGPT-powered helper for NL actions/assertions |
+
+**AI Agents & Autonomous Testing:**
+| Project | Description |
+|---------|-------------|
+| AIRAS Agent | Vision-enhanced browsing agent (Playwright + GPT-4V/Ollama) |
+| Skyvern | LLM + computer vision automation over browsers |
+| coTestPilot | GPT-4 Vision for AI bug detection with Playwright |
+| Steel.dev | Open-source browser API for AI agents at scale |
+
+**Advanced/Multimodal:**
+| Project | Description |
+|---------|-------------|
+| Playwright Mind | .ai, .aiQuery, .aiAssert powered by multimodal LLMs |
+| Playwright MCP Server | MCP server for LLM-driven Playwright tasks |
+
+### Critical Caveats
+- Most open-source projects are research-grade, not enterprise-ready
+- No SOC2 compliance, guaranteed reliability in CI, or production support
+- LLM variability means prompt crafting is critical for reliable output
+- Without application context, LLMs hallucinate tests from training data
+- Inference costs can be significant at scale (mitigated by local/open-source models)
+
+### 2026 Trend: Agentic Testing
+The convergence of MCP, AI agents, and Playwright is enabling a new paradigm:
+- Autonomous agents that set up environments, orchestrate tests, analyze results, and log defects
+- 72.3% of teams actively exploring or adopting AI-driven testing workflows
+- Gartner predicts 75% of companies will employ AI-driven automated processes by 2026
+
+---
+
+## 6. Industry Adoption Statistics
+
+| Metric | Value | Source |
+|--------|-------|--------|
+| Organizations using GenAI in QA | 68% | Sogeti World Quality Report 2024-25 |
+| QA teams adopting AI-driven testing | 61% | Katalon 2025 State of Software Quality |
+| Enterprises with AI in testing strategy | 33%+ | 2024 industry data |
+| Teams exploring AI testing workflows | 72.3% | 2024 survey data |
+| Predicted vendor consolidation | 5-7 major platforms | Industry forecast |
+| Legacy tool market share loss | Up to 50% | Industry forecast |
+
+---
+
+## 7. Strategic Opportunities for a New Entrant
+
+### The Gap: Developer-First, Playwright-Native, AI-Powered Testing SaaS
+
+Based on this research, the clearest market gap is:
+
+**A developer-first, Playwright-native testing platform with genuine AI capabilities, transparent pricing, and open-source code ownership.**
+
+### Why This Gap Exists
+
+1. **Enterprise tools** (Tricentis, BrowserStack) are too expensive and complex for startups/SMBs
+2. **AI-native tools** (Momentic, Testim) use proprietary execution - vendor lock-in
+3. **Managed services** (QA Wolf) are high-touch and expensive, not self-serve
+4. **Open-source AI+Playwright tools** are research-grade, not productized
+5. **Monitoring tools** (Checkly) focus on monitoring, not full test lifecycle
+6. **No one** combines: open-source Playwright + AI generation + self-healing + transparent pricing + developer experience
+
+### Potential Differentiators for a New Product
+
+1. **Playwright-native, code-you-own** - Like QA Wolf but self-serve SaaS
+2. **AI-powered test generation from actual app context** (not hallucinated) - Using MCP/accessibility tree
+3. **Self-healing with transparency** - Show what changed and why, not a black box
+4. **Developer-first UX** - CLI, Git integration, IDE extensions, not a QA dashboard
+5. **Transparent, usage-based pricing** - Start free, pay per execution minute or test run
+6. **Test-to-monitor pipeline** - One-click conversion of E2E tests to production monitors
+7. **Local/hybrid AI** - Support for local LLMs to address cost and data privacy concerns
+8. **MCP-native architecture** - Built on the emerging standard for AI-tool integration
+
+### Competitive Positioning Map
+
+```
+                    AI-Native
+                       |
+         Momentic   KaneAI   mabl
+              \       |      /
+               \      |     /
+    Proprietary ------+------ Open Source
+               /      |     \
+              /       |      \
+         Testim   [OPPORTUNITY]  QA Wolf
+              \       |      /
+               \      |     /
+                       |
+                  Traditional
+```
+
+The intersection of AI-Native + Open Source is the underserved quadrant.
+
+---
+
+## 8. Key Risks
+
+1. **Rapid commoditization** - AI test generation becoming a feature, not a product
+2. **Playwright evolving** - Microsoft adding AI features natively to Playwright (Test Agents, MCP)
+3. **Big player acquisitions** - Tricentis acquired Testim; BrowserStack or Microsoft could acquire more
+4. **LLM cost/reliability** - Inference costs and hallucination remain challenges
+5. **Vendor consolidation** - Predictions of 5-7 major platforms surviving
+6. **Open-source competition** - Strong community of free tools may limit willingness to pay
+
+---
+
+## Sources
+
+All data gathered from publicly available sources as of February 2, 2026.

--- a/notes/features/motqen-product-strategy.md
+++ b/notes/features/motqen-product-strategy.md
@@ -1,0 +1,457 @@
+# AI-Powered Testing Automation: Product Vision & Strategy
+
+**Author**: Product Strategist, ConnectSW
+**Date**: 2026-02-02
+**Status**: Draft for CEO Review
+
+---
+
+## 1. Product Name
+
+### Recommended: **TestPilot**
+
+A pilot navigates complexity, runs pre-flight checks, and ensures safe arrival. TestPilot does the same for software releases. Short, memorable, verb-like (pilot your tests), and implies both AI intelligence and autopilot-level autonomy.
+
+**Alternatives considered:**
+
+| Name | Pros | Cons |
+|------|------|------|
+| **TestPilot** | Strong metaphor, memorable, implies AI autonomy, available as npm package name | Aviation metaphor may feel overused |
+| **Guardrail** | Implies safety and quality gates, developer-friendly | Generic, could be confused with AI safety tools |
+| **Specwright** | Plays on "spec" (test spec) + "wright" (craftsman), connects to our Shipwright product | Harder to spell, less intuitive |
+| **Greenlight** | Implies CI passing, deployment confidence, positive association | Too generic, already used by other products |
+
+**TestPilot** is the recommendation. It works as a CLI command (`testpilot run`), a brand (`TestPilot by ConnectSW`), and a concept developers immediately grasp.
+
+---
+
+## 2. One-Line Value Proposition
+
+**"Write your first Playwright test in 30 seconds. Keep it passing forever."**
+
+The promise is twofold: AI generates correct, maintainable tests from natural language or by watching you use your app, and then autonomously repairs those tests when your UI changes -- eliminating the 60-80% of QA effort consumed by test maintenance.
+
+---
+
+## 3. Target Customer Segments
+
+### Primary: Startups and SMBs (10-200 engineers)
+
+- **Who**: Engineering teams at Series A-C startups who ship fast but lack dedicated QA
+- **Pain**: They know they need E2E tests but cannot justify a QA team. Manual testing slows releases. CI pipelines have no browser tests.
+- **Budget**: $200-2,000/month
+- **Buying motion**: Bottom-up, developer-led. One engineer installs it, team adopts within weeks.
+- **Why underserved**: QA Wolf charges $4K+/month. Tricentis requires enterprise contracts. Katalon and mabl target QA professionals, not developers.
+
+### Secondary: Platform Engineering Teams at Mid-Market Companies (200-2,000 employees)
+
+- **Who**: DevOps/Platform teams standardizing testing across 5-20 engineering squads
+- **Pain**: Inconsistent test coverage across teams. Flaky tests erode CI trust. New hires take weeks to learn the testing framework.
+- **Budget**: $2,000-10,000/month
+- **Buying motion**: Top-down from engineering leadership, evaluated by platform team.
+
+### Explicitly NOT targeting (initially):
+
+- **Enterprise (2,000+ employees)**: They already have Tricentis, Sauce Labs, and dedicated QA orgs. Winning them requires 12-month sales cycles and SOC 2 compliance.
+- **Non-developer QA teams**: Our moat is developer-first CLI/Git tooling. Drag-and-drop test builders (Katalon, Testim) serve the low-code QA market. We do not.
+
+---
+
+## 4. Positioning Statement
+
+**For engineering teams that ship weekly but test manually**, TestPilot is a developer-first testing platform that **generates and maintains Playwright E2E tests from natural language and app recordings**, so teams get 80% coverage without writing a single selector.
+
+Unlike QA Wolf (managed service, opaque, $4K+/month), Momentic (Chromium-only, no CI-native workflow), and Katalon (built for QA pros, not developers), TestPilot is:
+
+1. **A CLI tool that lives in your repo**, not a separate platform
+2. **Open-format Playwright**, not a proprietary test language
+3. **Self-healing in CI**, not just self-healing in a GUI
+4. **Pay-per-test-run**, not pay-per-seat
+
+The shortest way to say it: **TestPilot is Copilot for Playwright.**
+
+---
+
+## 5. Core Differentiators
+
+### Differentiator 1: CLI-First, Git-Native
+
+No other AI testing tool operates as a CLI that commits standard Playwright files directly into your repository. TestPilot tests are `.spec.ts` files. They run with `npx playwright test`. There is zero vendor lock-in.
+
+```bash
+# Generate a test from natural language
+testpilot generate "user logs in with valid credentials and sees dashboard"
+
+# Record a test by watching you use the app
+testpilot record --url http://localhost:3000
+
+# Heal broken tests in CI
+testpilot heal --ci
+```
+
+Why this matters: Developers trust tools that fit their workflow (terminal, Git, CI). Every competitor forces you into their web dashboard, their test format, or their cloud runner. TestPilot is Playwright. Full stop.
+
+### Differentiator 2: Self-Healing That Runs in CI (Not Just a GUI)
+
+Momentic and mabl self-heal at runtime in their proprietary runner. When selectors break, they figure out the new selector and proceed. But this creates a gap: the test file in your repo still has the old selector. The CI run "passed" but the source of truth is stale.
+
+TestPilot self-heals differently:
+
+1. Test fails in CI
+2. TestPilot analyzes the DOM diff, identifies the broken selector
+3. TestPilot opens a PR with the corrected selector
+4. Developer approves the 1-line diff
+
+The test file in Git is always the canonical source. Self-healing produces auditable code changes, not hidden runtime magic.
+
+### Differentiator 3: Open-Source Core, SaaS Platform
+
+The test generation CLI is open-source (MIT). Anyone can use `testpilot generate` locally. The SaaS layer adds:
+
+- Cloud test execution (parallel, cross-browser)
+- Self-healing CI integration (auto-PR on failure)
+- Test analytics (flake detection, coverage gaps)
+- Team management and usage dashboards
+
+This is the Supabase/PostHog model: open-source earns trust and adoption; the hosted platform earns revenue. No competitor has an OSS offering -- they all gate even basic functionality behind paid plans.
+
+### Differentiator 4: Built by a Team That Ships Real Playwright Tests
+
+This is not an academic exercise. ConnectSW has 13+ Playwright E2E specs in production across stablecoin-gateway, battle-tested patterns for auth fixtures, rate-limit mitigation, route interception, and CI reliability. We have felt every pain point firsthand:
+
+- Flaky selectors that break on minor UI changes
+- Auth token management in E2E contexts
+- Rate limiter interference with test execution
+- Page reload vs. client-side navigation traps
+- CI timing issues and retry strategies
+
+TestPilot is built from operational experience, not from a test framework tutorial.
+
+---
+
+## 6. Go-to-Market Strategy: First 100 Customers
+
+### Phase 1: Developer Community (Months 1-3) -- Target: 30 customers
+
+**Channel: Open-source launch on GitHub + Hacker News + dev Twitter/X**
+
+- Release `testpilot` CLI as MIT-licensed OSS
+- Write 3 viral blog posts:
+  - "We replaced 200 hours of manual testing with 30 seconds of AI"
+  - "Why your Playwright tests break every sprint (and how to fix it)"
+  - "The open-source alternative to QA Wolf"
+- Post `Show HN: TestPilot -- AI-generated Playwright tests from natural language`
+- Target 2,000 GitHub stars in first month (drives organic traffic)
+
+**Conversion**: Free CLI users hit the limit of local execution (slow, single-browser). Upgrade to cloud runner for parallel cross-browser testing at $49/month.
+
+### Phase 2: Content-Led Inbound (Months 3-6) -- Target: 40 customers
+
+**Channel: SEO + YouTube + Conference talks**
+
+- Publish weekly Playwright tutorials (SEO for "playwright tutorial", "e2e testing guide", "playwright best practices")
+- YouTube series: "Zero to 80% E2E Coverage" (5-part series)
+- Speak at 2-3 conferences: TestJS Summit, ViteConf, Node Congress
+- Sponsor Playwright community events
+
+**Conversion**: Tutorial readers discover TestPilot organically. Blog CTAs lead to free tier sign-up.
+
+### Phase 3: Direct Outreach (Months 4-6) -- Target: 30 customers
+
+**Channel: Targeted outreach to teams already using Playwright**
+
+- Scrape GitHub for repos with `playwright.config.ts` -- these teams already invested in Playwright and are most likely to adopt a tool that enhances it
+- Identify repos with `>50` test files (mature test suites likely experiencing maintenance pain)
+- Cold email eng leads: "We noticed your repo has 87 Playwright specs. How much time does your team spend fixing broken tests?"
+
+**Conversion**: Free trial of cloud runner + self-healing. 14-day trial, $0 card required.
+
+### Growth Flywheel
+
+```
+OSS stars --> Blog traffic --> Free tier sign-ups --> Cloud upgrades --> Case studies --> More traffic
+```
+
+**Target metrics at 6 months:**
+- 5,000+ GitHub stars
+- 500+ free tier users
+- 100+ paid customers
+- $30K MRR
+
+---
+
+## 7. Revenue Model
+
+### Pricing Philosophy
+
+Three principles:
+1. **Free tier must be genuinely useful** (not a demo that expires)
+2. **Price on execution, not seats** (aligns cost with value)
+3. **Transparent pricing on the website** (no "contact sales")
+
+### Pricing Tiers
+
+| Tier | Price | Included | Target |
+|------|-------|----------|--------|
+| **Community** (free forever) | $0 | CLI: generate + record locally. 50 cloud test runs/month. Single browser. | Individual devs, OSS projects |
+| **Team** | $49/month + $0.02/test run | 2,500 cloud runs included. 3 browsers (Chromium, Firefox, WebKit). Self-healing PRs. Slack notifications. | Startups, small teams (2-10 devs) |
+| **Scale** | $199/month + $0.015/test run | 15,000 cloud runs included. Parallel execution. Test analytics dashboard. Priority support. SSO. | Growth-stage companies (10-50 devs) |
+| **Enterprise** | Custom | Dedicated infrastructure. SLA. On-prem option. Custom integrations. Audit logs. | Mid-market, regulated industries |
+
+### Revenue Projections (Conservative)
+
+| Month | Free Users | Paid Customers | MRR |
+|-------|-----------|---------------|-----|
+| 3 | 200 | 30 | $5K |
+| 6 | 500 | 100 | $30K |
+| 12 | 2,000 | 350 | $120K |
+| 18 | 5,000 | 800 | $350K |
+| 24 | 10,000 | 1,500 | $700K |
+
+### Why Per-Test-Run Pricing Wins
+
+- **Aligns with value**: Customers pay more as they test more (and get more value)
+- **Low barrier to entry**: $49/month is a credit card expense, no procurement needed
+- **Predictable scaling**: Revenue grows with adoption, not with headcount
+- **Competitive advantage**: QA Wolf charges $4K+/month. mabl charges per credit (opaque). Katalon charges per license ($175/seat). We are the only transparent per-run model.
+
+---
+
+## 8. Competitive Moat
+
+### Short-term moat (Year 1): Developer experience + OSS community
+
+The CLI-first, open-format approach builds trust and community. Developers who contribute to the OSS project become evangelists. Switching cost is low (it is just Playwright files), but switching motivation is also low (why leave if it works and the community is great?).
+
+### Medium-term moat (Year 2): Self-healing intelligence
+
+Every self-healing PR we process teaches our model about selector patterns, DOM changes, and test intent. This data compounds. After processing 1M self-healing events, our AI understands Playwright test patterns better than any competitor that only sees their proprietary test format.
+
+### Long-term moat (Year 3+): Test-to-production pipeline
+
+TestPilot extends from test generation into production monitoring (like Checkly, but AI-native). The same AI that writes your tests also monitors your production app, detects regressions before users do, and automatically generates new tests for edge cases discovered in production. No competitor spans this full loop.
+
+### Data moat specifics
+
+| Data Asset | How We Collect | Competitive Advantage |
+|-----------|---------------|----------------------|
+| Selector patterns | Every generated test | Better selector stability than competitors |
+| DOM change patterns | Every self-healing PR | Predictive healing (fix before CI fails) |
+| Test intent graphs | Natural language inputs | Better test generation accuracy |
+| Flake signatures | Cloud runner telemetry | Flake detection and auto-quarantine |
+| Coverage gap models | Cross-customer anonymized data | "Your app has 0 tests for password reset -- generate?" |
+
+---
+
+## 9. Risk Assessment
+
+### Risk 1: AI Hallucination in Test Generation
+
+**Severity**: High
+**Probability**: Medium
+
+AI-generated tests may assert incorrect behavior, have hallucinated selectors, or test impossible user flows. If TestPilot generates bad tests, developers lose trust immediately and never return.
+
+**Mitigation strategy:**
+- Every generated test runs immediately against the target app before presenting to the user. If it fails, TestPilot iterates (up to 3 attempts) before returning a result.
+- Generated tests include a `// testpilot:confidence=0.92` annotation. Tests below 0.7 confidence are flagged for human review.
+- The CLI shows a diff-style preview: "Here is the test I wrote. Accept? [Y/n/edit]"
+- We track "generation accuracy" (% of generated tests that pass on first run) as our #1 product metric. Target: 85% within 6 months.
+
+### Risk 2: Playwright Dependency / Platform Risk
+
+**Severity**: Medium
+**Probability**: Low
+
+We are betting entirely on Playwright. If Playwright loses developer mindshare (e.g., a new framework emerges), or if Microsoft makes changes that break our tooling, we are exposed.
+
+**Mitigation strategy:**
+- Playwright is MIT-licensed and has massive momentum (90K+ GitHub stars, default choice for new projects). The risk of it disappearing is very low.
+- Our AI layer is framework-agnostic in architecture. The test generation model understands DOM interactions, not Playwright syntax specifically. Adding Cypress or a future framework requires a new output adapter, not a new model.
+- We contribute to the Playwright OSS project, building relationships with the core team and ensuring early awareness of breaking changes.
+
+### Risk 3: Large Player Enters With Built-In AI Testing
+
+**Severity**: High
+**Probability**: High
+
+Microsoft (Playwright's owner) could add AI test generation directly to Playwright. GitHub Copilot could add a "generate test" feature. Vercel could bundle testing into their platform.
+
+**Mitigation strategy:**
+- Microsoft/GitHub will likely offer a generic "generate test from code" feature (like Copilot does today). TestPilot's advantage is the full lifecycle: generation + self-healing + CI integration + analytics. A feature in an IDE cannot match a dedicated platform.
+- Speed to market matters. We ship TestPilot v1 in Q2 2026, building community and data moat before large players react. By the time Microsoft adds AI testing to Playwright (likely 2027), we will have 5,000+ users and millions of self-healing data points.
+- Our OSS + SaaS model means we can coexist with built-in features. If Playwright adds basic AI generation, TestPilot becomes the "advanced" layer on top -- like how Vercel coexists with Next.js.
+- We diversify the platform value beyond generation: self-healing, analytics, monitoring, and team collaboration are not features Microsoft will bundle into a testing framework.
+
+---
+
+## 10. Phase Roadmap
+
+### Phase 1: MVP -- "The Generator" (Q2 2026, 8 weeks)
+
+**Goal**: Ship the open-source CLI that generates Playwright tests from natural language. Get 2,000 GitHub stars and 30 paying customers.
+
+**Deliverables:**
+- `testpilot generate <prompt>` -- NL to Playwright spec
+- `testpilot record --url <url>` -- Record browser session, output spec
+- `testpilot run` -- Thin wrapper around `npx playwright test` with enhanced reporting
+- Cloud runner (SaaS): Run tests in parallel across Chromium, Firefox, WebKit
+- GitHub Action: `connectsw/testpilot-action@v1`
+- Landing page + docs site
+- Free + Team pricing tiers live
+
+**Technical architecture:**
+```
+CLI (OSS, TypeScript)
+  |-- generate: prompt -> LLM -> Playwright AST -> .spec.ts file
+  |-- record: browser CDP -> action log -> Playwright AST -> .spec.ts file
+  |-- run: spawn playwright, capture results, upload to cloud (if authenticated)
+
+Cloud Platform (SaaS)
+  |-- Runner: Containerized Playwright in parallel
+  |-- Dashboard: Test results, history, flake detection
+  |-- API: REST + webhooks for CI integration
+```
+
+**Key decisions:**
+- LLM: Claude API for test generation (our existing Anthropic relationship)
+- Infrastructure: Fly.io for cloud runners (fast cold starts, global regions)
+- Frontend: Next.js dashboard (our standard stack)
+- Backend: Fastify API (our standard stack)
+
+**Success criteria:**
+- Generation accuracy: 75%+ (tests pass on first run)
+- CLI install to first generated test: under 60 seconds
+- 2,000 GitHub stars
+- 30 paying Team customers
+
+### Phase 2: Self-Healing + Analytics -- "The Maintainer" (Q3 2026, 10 weeks)
+
+**Goal**: Ship the self-healing CI integration and test analytics. Reach 100 paying customers and $30K MRR.
+
+**Deliverables:**
+- `testpilot heal` -- Analyze failing test, identify broken selector, suggest fix
+- `testpilot heal --ci` -- Auto-create PR with fix when tests fail in CI
+- Test analytics dashboard:
+  - Flake detection and auto-quarantine
+  - Test duration trends
+  - Coverage gap analysis ("Your signup flow has 0 tests")
+  - Failure correlation ("Tests X, Y, Z always fail together")
+- Slack/Teams integration for test failure notifications
+- Scale pricing tier live
+
+**Technical additions:**
+```
+Self-Healing Engine
+  |-- DOM Differ: Compare failing test's expected DOM vs actual DOM
+  |-- Selector Resolver: Find best replacement selector (data-testid > role > text > css)
+  |-- PR Generator: Create minimal diff PR via GitHub API
+  |-- Confidence Scorer: Rate self-healing confidence, skip low-confidence fixes
+
+Analytics Pipeline
+  |-- Test result ingestion from cloud runner
+  |-- Flake detection (statistical analysis of pass/fail patterns)
+  |-- Coverage gap model (analyze app routes vs test coverage)
+```
+
+**Success criteria:**
+- Self-healing accuracy: 80%+ (healed tests pass)
+- Self-healing PR merge rate: 70%+ (developers accept the fix)
+- Flake detection: Identify 90%+ of flaky tests within 5 runs
+- 100 paying customers, $30K MRR
+
+### Phase 3: Production Monitoring -- "The Guardian" (Q4 2026 - Q1 2027, 14 weeks)
+
+**Goal**: Bridge the gap between testing and production monitoring. Reach 350 paying customers and $120K MRR.
+
+**Deliverables:**
+- `testpilot monitor` -- Run Playwright tests against production on a schedule
+- Synthetic monitoring: Run critical user flows every 5 minutes from global locations
+- Regression detection: AI compares production behavior against test expectations
+- Auto-generated tests from production traffic patterns
+- Custom alerting (PagerDuty, OpsGenie, Slack, email)
+- Enterprise tier: SSO, audit logs, on-prem runners, SLA
+- SOC 2 Type I certification (required for enterprise sales)
+
+**Technical additions:**
+```
+Monitoring Engine
+  |-- Scheduler: Cron-based test execution from global regions
+  |-- Comparison Engine: Diff production behavior vs test baselines
+  |-- Alert Router: Multi-channel alerting with escalation
+  |-- Traffic Analyzer: Identify untested production user flows
+  |-- Test Suggester: "Users frequently do X but you have no test for it"
+```
+
+**Success criteria:**
+- Monitoring uptime: 99.9%
+- Alert latency: under 60 seconds from detection to notification
+- 350 paying customers, $120K MRR
+- 3+ enterprise contracts signed
+- SOC 2 Type I complete
+
+---
+
+## Strategic Summary
+
+TestPilot is a bet on three converging trends:
+
+1. **Playwright is winning**. It has become the default E2E framework for new projects, and its momentum is accelerating. Building on Playwright means building on a growing foundation.
+
+2. **AI can finally write reliable tests**. LLMs in 2026 are good enough to generate correct Playwright tests from natural language, but only if you verify them against the actual app (not just generate and hope). The verify-then-present loop is our key insight.
+
+3. **Developers will pay for maintenance relief, not generation**. Test generation is a nice demo. Test maintenance is a $10B pain point. The self-healing PR workflow is the feature that converts free users to paid customers and paid customers to annual contracts.
+
+The strategic sequence is: **Get adopted** (free OSS CLI) then **become essential** (self-healing in CI) then **expand scope** (production monitoring). Each phase increases switching cost while maintaining the open-format, no-lock-in promise that earns developer trust in the first place.
+
+**Recommended next step**: CEO approval to begin Phase 1 technical architecture and assign engineering resources. Estimated team: 2 engineers (1 backend, 1 full-stack) for 8 weeks to reach MVP.
+
+---
+
+## Appendix A: Competitive Positioning Map
+
+```
+                    Developer-First
+                         |
+                    TestPilot
+                         |
+            Checkly ---- + ---- LambdaTest/KaneAI
+                         |
+     CLI/Git-Native -----+------ Web Dashboard
+                         |
+           Playwright ---+--- Proprietary Format
+                         |
+                    Momentic
+                         |
+                    QA-First
+                         |
+              mabl -- Katalon -- Tricentis
+```
+
+## Appendix B: Pricing Comparison
+
+| Feature | TestPilot Team ($49/mo) | QA Wolf (~$4K/mo) | Momentic (~$300/mo) | mabl (~$500/mo) | Katalon ($175/seat) |
+|---------|------------------------|--------------------|--------------------|-----------------|---------------------|
+| AI test generation | Yes (NL + record) | Managed service | Yes (NL) | Yes (auto-heal) | Limited |
+| Self-healing | PR-based (auditable) | Managed | Runtime (hidden) | Runtime (hidden) | No |
+| Open-source | Yes (CLI) | No | No | No | No |
+| Playwright native | Yes | Yes | No (Chromium only) | No (proprietary) | No (proprietary) |
+| Cross-browser | Yes (3 engines) | Yes | No | Yes | Yes |
+| CI integration | Native (GH Action) | Managed | Yes | Yes | Yes |
+| Vendor lock-in | None (standard .spec.ts) | High | High | High | High |
+| Transparent pricing | Yes | No | Somewhat | No | Somewhat |
+
+## Appendix C: ConnectSW Internal Capabilities Audit
+
+Relevant existing assets that accelerate TestPilot development:
+
+| Asset | Source Product | Reuse Potential |
+|-------|--------------|-----------------|
+| Playwright E2E test patterns | stablecoin-gateway (13 specs) | Direct: Informs test generation templates |
+| Auth fixture pattern (route interception) | stablecoin-gateway | Direct: Built-in auth handling for generated tests |
+| Rate-limit-aware testing | stablecoin-gateway | Direct: TestPilot avoids triggering rate limits in generated tests |
+| Fastify API backend | All products | Direct: Cloud runner API uses same stack |
+| Next.js frontend | All products | Direct: Dashboard uses same stack |
+| GitHub Actions CI | All products | Direct: GitHub Action uses same patterns |
+| Monorepo structure | Company standard | Direct: TestPilot follows same `apps/api + apps/web` structure |
+| TDD workflow | Company standard | Meta: TestPilot itself is built with TDD, validating its own test generation |


### PR DESCRIPTION
## Summary
- Add **Component Registry** (`.claude/COMPONENT-REGISTRY.md`) — catalogs 25+ reusable components across all ConnectSW products with "I Need To..." quick lookup table
- Integrate registry into **orchestrator workflow** — agents now check for existing components before building anything new ("Reuse before rebuild" as Principle #1)
- Add **Motqen** (متقن) product planning docs — market research and product strategy for AI-powered Playwright testing automation SaaS

## Files
- `.claude/COMPONENT-REGISTRY.md` — 571-line registry covering backend plugins, services, utilities, frontend hooks/components, and infrastructure templates
- `.claude/CLAUDE.md` — added mandatory Component Reuse section
- `.claude/orchestrator/orchestrator-enhanced.md` — registry as System #0, updated agent prompt template
- `notes/features/ai-testing-automation-market-research.md` — competitive landscape and market sizing
- `notes/features/motqen-product-strategy.md` — product vision, positioning, pricing, GTM, roadmap

## Test plan
- [ ] Verify `.claude/COMPONENT-REGISTRY.md` is readable and all source paths reference real files
- [ ] Verify orchestrator instructions reference the registry correctly
- [ ] Verify CLAUDE.md component reuse section is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)