### PR TITLE
feat(infra): parallel development with worktrees

### DIFF
--- a/.claude/scripts/worktree.sh
+++ b/.claude/scripts/worktree.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# worktree.sh - Manage git worktrees for parallel product development
+#
+# Usage:
+#   ./worktree.sh create <product> [branch]   Create a worktree for a product
+#   ./worktree.sh list                        List active worktrees
+#   ./worktree.sh remove <product>            Remove a worktree (keeps branch)
+#   ./worktree.sh path <product>              Print worktree path
+#
+# Worktrees are created in <repo>-worktrees/<product>/
+# Each gets its own branch checkout sharing the same .git database.
+# Hooks are inherited automatically from the main repo.
+
+set -euo pipefail
+
+# Resolve the main repo root (works from worktrees too)
+GIT_COMMON_DIR="$(git rev-parse --git-common-dir 2>/dev/null)"
+if [ "$GIT_COMMON_DIR" = ".git" ]; then
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+else
+  # We're in a worktree; common dir is <main-repo>/.git
+  REPO_ROOT="$(dirname "$GIT_COMMON_DIR")"
+fi
+
+WORKTREE_BASE="${REPO_ROOT}-worktrees"
+
+usage() {
+  echo "Usage: $(basename "$0") <command> [args]"
+  echo ""
+  echo "Commands:"
+  echo "  create <product> [branch]  Create worktree (default branch: feature/<product>/dev)"
+  echo "  list                       List active worktrees"
+  echo "  remove <product>           Remove worktree (keeps branch)"
+  echo "  path <product>             Print worktree path"
+  exit 1
+}
+
+cmd_create() {
+  local product="${1:-}"
+  local branch="${2:-}"
+
+  if [ -z "$product" ]; then
+    echo "Error: product name required"
+    echo "Usage: $(basename "$0") create <product> [branch]"
+    exit 1
+  fi
+
+  local worktree_path="${WORKTREE_BASE}/${product}"
+
+  if [ -d "$worktree_path" ]; then
+    echo "Error: worktree already exists at ${worktree_path}"
+    echo "Use '$(basename "$0") remove ${product}' first, or work in the existing one."
+    exit 1
+  fi
+
+  # Default branch name if not provided
+  if [ -z "$branch" ]; then
+    branch="feature/${product}/dev"
+  fi
+
+  # Check if branch already exists
+  if git show-ref --verify --quiet "refs/heads/${branch}" 2>/dev/null; then
+    echo "Checking out existing branch: ${branch}"
+    git worktree add "$worktree_path" "$branch"
+  else
+    echo "Creating new branch: ${branch}"
+    git worktree add -b "$branch" "$worktree_path"
+  fi
+
+  echo ""
+  echo "Worktree created:"
+  echo "  Path:   ${worktree_path}"
+  echo "  Branch: ${branch}"
+  echo ""
+  echo "Next steps:"
+  echo "  cd \"${worktree_path}\""
+  echo "  # Install deps for the product you're working on:"
+  echo "  cd products/${product} && npm install"
+}
+
+cmd_list() {
+  echo "Active worktrees:"
+  echo ""
+  git worktree list
+}
+
+cmd_remove() {
+  local product="${1:-}"
+
+  if [ -z "$product" ]; then
+    echo "Error: product name required"
+    echo "Usage: $(basename "$0") remove <product>"
+    exit 1
+  fi
+
+  local worktree_path="${WORKTREE_BASE}/${product}"
+
+  if [ ! -d "$worktree_path" ]; then
+    echo "Error: no worktree found at ${worktree_path}"
+    exit 1
+  fi
+
+  # Get branch name before removing
+  local branch
+  branch="$(git -C "$worktree_path" branch --show-current 2>/dev/null || echo "unknown")"
+
+  git worktree remove "$worktree_path" --force
+
+  echo "Worktree removed: ${worktree_path}"
+  echo "Branch '${branch}' is still available (not deleted)."
+
+  # Clean up empty parent directory
+  if [ -d "$WORKTREE_BASE" ] && [ -z "$(ls -A "$WORKTREE_BASE" 2>/dev/null)" ]; then
+    rmdir "$WORKTREE_BASE"
+    echo "Cleaned up empty worktree base directory."
+  fi
+}
+
+cmd_path() {
+  local product="${1:-}"
+
+  if [ -z "$product" ]; then
+    echo "Error: product name required"
+    echo "Usage: $(basename "$0") path <product>"
+    exit 1
+  fi
+
+  local worktree_path="${WORKTREE_BASE}/${product}"
+
+  if [ ! -d "$worktree_path" ]; then
+    echo "Error: no worktree found at ${worktree_path}" >&2
+    exit 1
+  fi
+
+  echo "$worktree_path"
+}
+
+# Main dispatch
+command="${1:-}"
+shift || true
+
+case "$command" in
+  create)  cmd_create "$@" ;;
+  list)    cmd_list ;;
+  remove)  cmd_remove "$@" ;;
+  path)    cmd_path "$@" ;;
+  *)       usage ;;
+esac

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# Merge strategies for parallel product development
+#
+# Problem: When two Claude sessions work on different products simultaneously,
+# PRs can conflict on shared root config files that neither session changed
+# intentionally.
+#
+# merge=ours:  On conflict, keeps the version on the target branch (main).
+#              Safe because root config changes are rare and deliberate.
+#              If a PR intentionally modifies these, re-apply after merge.
+#
+# merge=union: On conflict, keeps lines from both sides.
+#              Works for append-only files with independent entries.
+
+# Root configs - keep main's version on conflict
+package.json           merge=ours
+package-lock.json      merge=ours
+tsconfig.json          merge=ours
+.eslintrc.js           merge=ours
+.prettierrc            merge=ours
+
+# Append-only registries - keep both sides' additions
+.claude/PORT-REGISTRY.md  merge=union

--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -3,7 +3,13 @@
 # Passively logs commit metadata to audit-trail.jsonl.
 # Install: git config core.hooksPath .githooks
 
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+GIT_COMMON_DIR="$(git rev-parse --git-common-dir 2>/dev/null)"
+if [ "$GIT_COMMON_DIR" = ".git" ]; then
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+else
+  # In a worktree, common dir is <main-repo>/.git — go up one level
+  REPO_ROOT="$(dirname "$GIT_COMMON_DIR")"
+fi
 AUDIT_FILE="$REPO_ROOT/.claude/audit-trail.jsonl"
 
 [ -z "$REPO_ROOT" ] && exit 0

--- a/docs/PARALLEL-DEVELOPMENT.md
+++ b/docs/PARALLEL-DEVELOPMENT.md
@@ -1,0 +1,86 @@
+# Parallel Product Development
+
+Run multiple Claude sessions on different products simultaneously using git worktrees.
+
+## Quick Start
+
+```bash
+# Create a worktree for a product
+.claude/scripts/worktree.sh create stablecoin-gateway
+
+# Work in it
+cd "$(git rev-parse --show-toplevel)-worktrees/stablecoin-gateway"
+cd products/stablecoin-gateway && npm install
+
+# When done, remove the worktree (branch is kept)
+.claude/scripts/worktree.sh remove stablecoin-gateway
+```
+
+## How It Works
+
+Git worktrees let you check out multiple branches simultaneously in separate directories. Each worktree shares the same `.git` database, so commits, branches, and hooks are all synchronized.
+
+**Directory layout after creating worktrees:**
+
+```
+~/Desktop/Projects/
+  Claude Code creates the SW company/              # main repo (any branch)
+  Claude Code creates the SW company-worktrees/
+    stablecoin-gateway/                             # worktree on its own branch
+    invoiceforge/                                   # worktree on its own branch
+```
+
+Each worktree:
+- Has its own branch checked out
+- Can run its own dev servers (ports don't conflict - see PORT-REGISTRY.md)
+- Inherits git hooks from `.githooks/`
+- Can commit, push, and create PRs independently
+
+## Commands
+
+| Command | What It Does |
+|---------|-------------|
+| `worktree.sh create <product> [branch]` | Creates worktree; defaults to `feature/<product>/dev` branch |
+| `worktree.sh list` | Shows all active worktrees |
+| `worktree.sh remove <product>` | Removes worktree (keeps the branch) |
+| `worktree.sh path <product>` | Prints the worktree path (for scripting) |
+
+## When to Use Worktrees vs. Branch Switching
+
+| Scenario | Use |
+|----------|-----|
+| Two sessions working on different products at the same time | **Worktrees** |
+| One session, switching between products sequentially | **Branch switching** (simpler) |
+| Running dev servers for two products simultaneously | **Worktrees** |
+| Quick fix on one product while another is mid-feature | **Worktrees** |
+
+## Merge Strategy for Shared Files
+
+The `.gitattributes` file defines merge strategies so parallel PRs don't conflict on files neither changed intentionally:
+
+| File | Strategy | What Happens on Conflict |
+|------|----------|--------------------------|
+| `package.json` | `merge=ours` | Keeps main's version |
+| `package-lock.json` | `merge=ours` | Keeps main's version |
+| `tsconfig.json` | `merge=ours` | Keeps main's version |
+| `.eslintrc.js` | `merge=ours` | Keeps main's version |
+| `.prettierrc` | `merge=ours` | Keeps main's version |
+| `.claude/PORT-REGISTRY.md` | `merge=union` | Keeps lines from both sides |
+
+**Important**: If your PR intentionally modifies a `merge=ours` file (e.g., adds a script to root `package.json`), that change may be silently dropped if another PR merges first. Re-apply the change after merge.
+
+## Reverting Everything
+
+```bash
+# 1. Remove all worktrees
+.claude/scripts/worktree.sh list
+.claude/scripts/worktree.sh remove <product>  # for each active worktree
+
+# 2. Remove .gitattributes to revert merge strategies
+rm .gitattributes
+
+# 3. Remove the worktree script and this doc
+rm .claude/scripts/worktree.sh docs/PARALLEL-DEVELOPMENT.md
+```
+
+All changes are fully reversible with zero side effects.

--- a/notes/features/parallel-dev-worktrees.md
+++ b/notes/features/parallel-dev-worktrees.md
@@ -1,0 +1,17 @@
+# Parallel Development with Git Worktrees
+
+## Purpose
+Enable multiple Claude sessions to work on different products simultaneously
+without branch conflicts or working directory contention.
+
+## Deliverables
+1. `.gitattributes` - merge strategies for shared root files
+2. `.claude/scripts/worktree.sh` - helper script for worktree management
+3. `docs/PARALLEL-DEVELOPMENT.md` - usage documentation
+4. `.githooks/post-commit` fix - centralize audit log from worktrees
+
+## Key Decisions
+- `merge=ours` for root configs (package.json, tsconfig, etc.)
+- `merge=union` for PORT-REGISTRY.md (append-only)
+- Worktree directory: `<repo>-worktrees/<product>/`
+- Already gitignored via `*-worktrees/` pattern in .gitignore


### PR DESCRIPTION
## Summary

- Add `.gitattributes` with merge strategies (`merge=ours` for root configs, `merge=union` for PORT-REGISTRY) to auto-resolve conflicts when parallel product PRs touch shared files
- Add `worktree.sh` helper script with `create`, `list`, `remove`, `path` commands for managing per-product worktrees
- Fix `post-commit` hook to centralize audit log when committing from a worktree
- Add parallel development documentation

## Problems Solved

| # | Problem | Solution |
|---|---------|----------|
| 1 | Two Claude sessions can't work on different products simultaneously | Worktree script creates isolated working directories per product |
| 2 | Switching between products requires stash/switch dance | Each worktree has its own branch checkout |
| 3 | PR merges conflict on shared root files | `.gitattributes` defines auto-resolve merge strategies |

## Files Changed

| File | Action |
|------|--------|
| `.gitattributes` | Created |
| `.claude/scripts/worktree.sh` | Created |
| `docs/PARALLEL-DEVELOPMENT.md` | Created |
| `.githooks/post-commit` | Edited (2-line fix for worktree audit log) |
| `notes/features/parallel-dev-worktrees.md` | Created |

## Test Plan

- [x] `git check-attr merge package.json` returns `merge: ours`
- [x] `git check-attr merge .claude/PORT-REGISTRY.md` returns `merge: union`
- [x] `worktree.sh create stablecoin-gateway` creates worktree at correct path
- [x] `git worktree list` shows both main repo and worktree
- [x] `git config core.hooksPath` in worktree returns `.githooks`
- [x] `worktree.sh remove stablecoin-gateway` cleans up correctly
- [x] No changes to package.json, CI workflows, tsconfig, or any product code