### PR TITLE
refactor(infra): move worktrees into .tree/ inside repo

### DIFF
--- a/.claude/scripts/worktree.sh
+++ b/.claude/scripts/worktree.sh
@@ -7,9 +7,10 @@
 #   ./worktree.sh remove <product>            Remove a worktree (keeps branch)
 #   ./worktree.sh path <product>              Print worktree path
 #
-# Worktrees are created in <repo>-worktrees/<product>/
+# Worktrees are created in <repo>/.tree/<product>/
 # Each gets its own branch checkout sharing the same .git database.
 # Hooks are inherited automatically from the main repo.
+# The .tree/ directory is gitignored.
 
 set -euo pipefail
 
@@ -22,7 +23,7 @@ else
   REPO_ROOT="$(dirname "$GIT_COMMON_DIR")"
 fi
 
-WORKTREE_BASE="${REPO_ROOT}-worktrees"
+WORKTREE_BASE="${REPO_ROOT}/.tree"
 
 usage() {
   echo "Usage: $(basename "$0") <command> [args]"

--- a/.gitignore
+++ b/.gitignore
@@ -78,4 +78,5 @@ pnpm-lock.yaml
 # Docker
 docker-compose.override.yml
 .trees/
+.tree/
 .claude/audit-trail.jsonl

--- a/docs/PARALLEL-DEVELOPMENT.md
+++ b/docs/PARALLEL-DEVELOPMENT.md
@@ -9,7 +9,7 @@ Run multiple Claude sessions on different products simultaneously using git work
 .claude/scripts/worktree.sh create stablecoin-gateway
 
 # Work in it
-cd "$(git rev-parse --show-toplevel)-worktrees/stablecoin-gateway"
+cd "$(git rev-parse --show-toplevel)/.tree/stablecoin-gateway"
 cd products/stablecoin-gateway && npm install
 
 # When done, remove the worktree (branch is kept)
@@ -23,11 +23,11 @@ Git worktrees let you check out multiple branches simultaneously in separate dir
 **Directory layout after creating worktrees:**
 
 ```
-~/Desktop/Projects/
-  Claude Code creates the SW company/              # main repo (any branch)
-  Claude Code creates the SW company-worktrees/
-    stablecoin-gateway/                             # worktree on its own branch
-    invoiceforge/                                   # worktree on its own branch
+Claude Code creates the SW company/
+  .tree/
+    stablecoin-gateway/     # worktree on its own branch
+    invoiceforge/           # worktree on its own branch
+  products/                 # main repo products
 ```
 
 Each worktree:


### PR DESCRIPTION
## Summary

- Move worktree base directory from `<repo>-worktrees/` (outside repo) to `<repo>/.tree/` (inside repo, gitignored)
- Add `.tree/` to `.gitignore`
- Update worktree.sh and docs to reflect the new path

## Worktrees Created

All 7 products now have dedicated worktrees:

| Product | Branch | Path |
|---------|--------|------|
| deal-flow-platform | `feature/deal-flow-platform/dev` | `.tree/deal-flow-platform/` |
| invoiceforge | `feature/invoiceforge/dev` | `.tree/invoiceforge/` |
| meetingmind | `feature/meetingmind/dev` | `.tree/meetingmind/` |
| motqen | `feature/motqen/dev` | `.tree/motqen/` |
| quantum-computing-usecases | `feature/quantum-computing-usecases/dev` | `.tree/quantum-computing-usecases/` |
| shipwright | `feature/shipwright/dev` | `.tree/shipwright/` |
| stablecoin-gateway | `feature/stablecoin-gateway/dev` | `.tree/stablecoin-gateway/` |

## Test Plan

- [x] `.tree/` directory is gitignored (doesn't show in `git status`)
- [x] All 7 worktrees created successfully
- [x] `worktree.sh list` shows all 8 entries (main + 7 products)
- [x] Hooks inherited in worktrees (`core.hooksPath = .githooks`)