### PR TITLE
chore: gitignore workspace files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,4 +79,5 @@ pnpm-lock.yaml
 docker-compose.override.yml
 .trees/
 .tree/
+*.code-workspace
 .claude/audit-trail.jsonl


### PR DESCRIPTION
## Summary

- Add `*.code-workspace` to `.gitignore`

These are local dev convenience files for the multi-root workspace setup and shouldn't be tracked.