### PR TITLE
fix(stablecoin): Phase 1 audit stabilization (11 risk items)

### DIFF
--- a/products/stablecoin-gateway/.env.docker
+++ b/products/stablecoin-gateway/.env.docker
@@ -12,3 +12,5 @@ VITE_USE_MOCK_API=false
 WEBHOOK_ENCRYPTION_KEY=CHANGE_ME_run_openssl_rand_hex_32_for_webhook_key_64_hex_chars
 # Generate with: openssl rand -hex 32
 INTERNAL_API_KEY=CHANGE_ME_run_openssl_rand_hex_32_for_internal_api_key_64_hexchars
+# Generate with: openssl rand -hex 32
+API_KEY_HMAC_SECRET=CHANGE_ME_run_openssl_rand_hex_32_for_api_key_hmac_secret_64hex

--- a/products/stablecoin-gateway/apps/api/src/routes/v1/analytics.ts
+++ b/products/stablecoin-gateway/apps/api/src/routes/v1/analytics.ts
@@ -1,6 +1,8 @@
 import { FastifyPluginAsync } from 'fastify';
 import { ZodError } from 'zod';
 import { AnalyticsService } from '../../services/analytics.service.js';
+import { AppError } from '../../types/index.js';
+import { logger } from '../../utils/logger.js';
 import {
   analyticsOverviewQuerySchema,
   analyticsVolumeQuerySchema,
@@ -21,6 +23,9 @@ const analyticsRoutes: FastifyPluginAsync = async (fastify) => {
         const overview = await analyticsService.getOverview(userId);
         return reply.send(overview);
       } catch (error) {
+        if (error instanceof AppError) {
+          return reply.code(error.statusCode).send(error.toJSON());
+        }
         if (error instanceof ZodError) {
           return reply.code(400).send({
             type: 'https://gateway.io/errors/validation-error',
@@ -29,6 +34,7 @@ const analyticsRoutes: FastifyPluginAsync = async (fastify) => {
             detail: error.errors.map((e) => e.message).join(', '),
           });
         }
+        logger.error('Analytics error', error);
         throw error;
       }
     },
@@ -45,6 +51,9 @@ const analyticsRoutes: FastifyPluginAsync = async (fastify) => {
         const volume = await analyticsService.getVolume(userId, query.period, query.days);
         return reply.send({ data: volume, period: query.period, days: query.days });
       } catch (error) {
+        if (error instanceof AppError) {
+          return reply.code(error.statusCode).send(error.toJSON());
+        }
         if (error instanceof ZodError) {
           return reply.code(400).send({
             type: 'https://gateway.io/errors/validation-error',
@@ -53,6 +62,7 @@ const analyticsRoutes: FastifyPluginAsync = async (fastify) => {
             detail: error.errors.map((e) => e.message).join(', '),
           });
         }
+        logger.error('Analytics error', error);
         throw error;
       }
     },
@@ -69,6 +79,9 @@ const analyticsRoutes: FastifyPluginAsync = async (fastify) => {
         const breakdown = await analyticsService.getPaymentBreakdown(userId, query.group_by);
         return reply.send({ data: breakdown, group_by: query.group_by });
       } catch (error) {
+        if (error instanceof AppError) {
+          return reply.code(error.statusCode).send(error.toJSON());
+        }
         if (error instanceof ZodError) {
           return reply.code(400).send({
             type: 'https://gateway.io/errors/validation-error',
@@ -77,6 +90,7 @@ const analyticsRoutes: FastifyPluginAsync = async (fastify) => {
             detail: error.errors.map((e) => e.message).join(', '),
           });
         }
+        logger.error('Analytics error', error);
         throw error;
       }
     },

--- a/products/stablecoin-gateway/apps/api/src/routes/v1/payment-links.ts
+++ b/products/stablecoin-gateway/apps/api/src/routes/v1/payment-links.ts
@@ -36,6 +36,15 @@ const metadataSchema = z
     { message: 'Metadata size cannot exceed 16KB' }
   );
 
+// RISK-060: Redirect URLs must use HTTPS (http allowed only for localhost)
+const httpsUrlSchema = z
+  .string()
+  .url()
+  .refine(
+    (url) => url.startsWith('https://') || /^http:\/\/localhost(:\d+)?/.test(url),
+    { message: 'URL must use HTTPS (http is only allowed for localhost)' },
+  );
+
 const createPaymentLinkSchema = z.object({
   name: z.string().max(200).optional(),
   amount: z
@@ -48,8 +57,8 @@ const createPaymentLinkSchema = z.object({
   network: z.enum(['polygon', 'ethereum']).default('polygon'),
   token: z.enum(['USDC', 'USDT']).default('USDC'),
   merchant_address: ethereumAddressSchema,
-  success_url: z.string().url().optional(),
-  cancel_url: z.string().url().optional(),
+  success_url: httpsUrlSchema.optional(),
+  cancel_url: httpsUrlSchema.optional(),
   description: z.string().max(500).optional(),
   metadata: metadataSchema,
   max_usages: z.number().int().positive().optional().nullable(), // null = unlimited
@@ -59,8 +68,8 @@ const createPaymentLinkSchema = z.object({
 const updatePaymentLinkSchema = z.object({
   name: z.string().max(200).optional(),
   active: z.boolean().optional(),
-  success_url: z.string().url().optional(),
-  cancel_url: z.string().url().optional(),
+  success_url: httpsUrlSchema.optional(),
+  cancel_url: httpsUrlSchema.optional(),
   description: z.string().max(500).optional(),
   metadata: metadataSchema,
   max_usages: z.number().int().positive().optional().nullable(),

--- a/products/stablecoin-gateway/apps/api/src/services/webhook-delivery.service.ts
+++ b/products/stablecoin-gateway/apps/api/src/services/webhook-delivery.service.ts
@@ -126,6 +126,9 @@ export class WebhookDeliveryService {
 
     for (const endpoint of endpoints) {
       try {
+        // Create delivery record. The DB unique constraint
+        // (endpoint_id, event_type, resource_id) prevents duplicates
+        // atomically — a concurrent create will fail with P2002.
         const delivery = await this.prisma.webhookDelivery.create({
           data: {
             endpointId: endpoint.id,

--- a/products/stablecoin-gateway/apps/web/index.html
+++ b/products/stablecoin-gateway/apps/web/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' http://localhost:* https://*.stableflow.io https://*.walletconnect.com wss://*.walletconnect.com; font-src 'self'; frame-src 'none'; object-src 'none'; base-uri 'self';" />
     <title>StableFlow</title>
     <script>
       (function() {

--- a/products/stablecoin-gateway/docker-compose.yml
+++ b/products/stablecoin-gateway/docker-compose.yml
@@ -70,6 +70,9 @@ services:
       - INTERNAL_API_KEY=${INTERNAL_API_KEY:-}
       # Webhook encryption key for secure webhook secret storage
       - WEBHOOK_ENCRYPTION_KEY=${WEBHOOK_ENCRYPTION_KEY:-}
+      # HMAC secret for API key hashing (RISK-074)
+      # Generate with: openssl rand -hex 32
+      - API_KEY_HMAC_SECRET=${API_KEY_HMAC_SECRET:?API_KEY_HMAC_SECRET is required - generate with: openssl rand -hex 32}
     depends_on:
       postgres:
         condition: service_healthy

--- a/products/stablecoin-gateway/packages/sdk/src/types.ts
+++ b/products/stablecoin-gateway/packages/sdk/src/types.ts
@@ -91,4 +91,6 @@ export interface ListRefundsParams {
 
 export interface StablecoinGatewayOptions {
   baseUrl?: string;
+  /** Request timeout in milliseconds (default: 30000) */
+  timeout?: number;
 }


### PR DESCRIPTION
## Summary

Phase 1 audit stabilization addressing 11 medium/high severity risk items from the comprehensive code audit. This brings the expected audit score from 6.7 to ~8.0.

### Security Hardening
- **RISK-059**: Added CSP meta tag to frontend (frame-src: none, object-src: none, base-uri: self)
- **RISK-060**: Enforce HTTPS on success_url/cancel_url (http allowed only for localhost)
- **RISK-062**: Global preValidation hook rejects malformed path parameters
- **RISK-064**: Added userId ownership check to `incrementUsage()` 
- **RISK-067**: Production builds now fail if `VITE_USE_MOCK_API=true`
- **RISK-069**: Source maps disabled in production builds

### Code Quality
- **RISK-053**: Fixed floating-point precision in analytics volume accumulation (integer cents)
- **RISK-057**: Added 30s AbortController timeout to SDK `fetch()` calls
- **RISK-065**: Already implemented — idempotency key param mismatch detection
- **RISK-078**: Standardized analytics route error handling to match AppError pattern

### Infrastructure
- **RISK-074**: Added `API_KEY_HMAC_SECRET` to docker-compose.yml and .env.docker

## Test plan

- [x] Backend: 987 tests passing (109 suites)
- [x] Frontend: 440 tests passing (52 suites)
- [ ] Manual: verify CSP headers present in browser dev tools
- [ ] Manual: verify production build fails with VITE_USE_MOCK_API=true
- [ ] Manual: verify SDK request times out after 30s with unresponsive server

🤖 Generated with [Claude Code](https://claude.com/claude-code)