### PR TITLE
feat(pulse): wire up email/password auth flow e2e

### DIFF
--- a/products/pulse/apps/web/src/app/dashboard/layout.tsx
+++ b/products/pulse/apps/web/src/app/dashboard/layout.tsx
@@ -1,8 +1,11 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 import Sidebar from '../../components/layout/Sidebar';
 import Header from '../../components/layout/Header';
+import { TokenManager } from '../../lib/token-manager';
+import { useAuth } from '../../hooks/useAuth';
 
 export default function DashboardLayout({
   children,
@@ -10,13 +13,36 @@ export default function DashboardLayout({
   children: React.ReactNode;
 }) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [checked, setChecked] = useState(false);
+  const router = useRouter();
+  const { logout } = useAuth();
+
+  const handleLogout = async () => {
+    try {
+      await logout();
+    } finally {
+      router.replace('/login');
+    }
+  };
+
+  useEffect(() => {
+    if (!TokenManager.hasToken()) {
+      router.replace('/login');
+    } else {
+      setChecked(true);
+    }
+  }, [router]);
+
+  if (!checked) {
+    return null;
+  }
 
   return (
     <div className="min-h-screen bg-[var(--bg-page)]">
       <a href="#main-content" className="skip-to-content">
         Skip to main content
       </a>
-      <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+      <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} onLogout={handleLogout} />
       <div className="md:ml-56">
         <Header onMenuClick={() => setSidebarOpen(true)} />
         <main id="main-content" className="p-6" role="main">

--- a/products/pulse/apps/web/src/app/login/page.tsx
+++ b/products/pulse/apps/web/src/app/login/page.tsx
@@ -1,25 +1,25 @@
 'use client';
 
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
+import { useAuth } from '../../hooks/useAuth';
 
 export default function LoginPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
+  const router = useRouter();
+  const { login, isLoading } = useAuth();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setIsLoading(true);
     setError(null);
     try {
-      // TODO: integrate with apiClient.login
-      console.log('Login:', { email, password });
+      await login(email, password);
+      router.push('/dashboard');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Login failed');
-    } finally {
-      setIsLoading(false);
     }
   };
 

--- a/products/pulse/apps/web/src/app/signup/page.tsx
+++ b/products/pulse/apps/web/src/app/signup/page.tsx
@@ -1,26 +1,26 @@
 'use client';
 
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
+import { useAuth } from '../../hooks/useAuth';
 
 export default function SignupPage() {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
+  const router = useRouter();
+  const { signup, isLoading } = useAuth();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setIsLoading(true);
     setError(null);
     try {
-      // TODO: integrate with apiClient.signup
-      console.log('Signup:', { name, email, password });
+      await signup(name, email, password);
+      router.push('/dashboard');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Registration failed');
-    } finally {
-      setIsLoading(false);
     }
   };
 

--- a/products/pulse/apps/web/src/components/layout/Sidebar.tsx
+++ b/products/pulse/apps/web/src/components/layout/Sidebar.tsx
@@ -132,9 +132,10 @@ function NavItem({
 interface SidebarProps {
   isOpen?: boolean;
   onClose?: () => void;
+  onLogout?: () => void;
 }
 
-export default function Sidebar({ isOpen = true, onClose }: SidebarProps) {
+export default function Sidebar({ isOpen = true, onClose, onLogout }: SidebarProps) {
   const handleNavClick = () => {
     if (onClose) {
       onClose();
@@ -193,6 +194,7 @@ export default function Sidebar({ isOpen = true, onClose }: SidebarProps) {
 
         <div className="px-3 py-4 border-t border-[var(--border-card)]">
           <button
+            onClick={onLogout}
             className="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium text-[var(--text-secondary)] hover:bg-[var(--bg-sidebar-hover)] hover:text-[var(--text-primary)] transition-colors"
           >
             <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>

--- a/products/pulse/apps/web/src/hooks/useAuth.ts
+++ b/products/pulse/apps/web/src/hooks/useAuth.ts
@@ -8,7 +8,6 @@ export interface User {
   id: string;
   email: string;
   name?: string;
-  role: string;
   githubUsername?: string;
 }
 
@@ -46,10 +45,10 @@ export function useAuth() {
     try {
       const result = await apiClient.login(email, password);
       const user: User = {
-        id: result.id,
-        email: result.email,
-        role: result.role,
-        name: result.name,
+        id: result.user.id,
+        email: result.user.email,
+        name: result.user.name ?? undefined,
+        githubUsername: result.user.githubUsername ?? undefined,
       };
       storedUser = user;
 
@@ -63,6 +62,39 @@ export function useAuth() {
       return result;
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Login failed';
+      setState({
+        user: null,
+        isAuthenticated: false,
+        isLoading: false,
+        error: message,
+      });
+      throw error;
+    }
+  }, []);
+
+  const signup = useCallback(async (name: string, email: string, password: string) => {
+    setState((prev) => ({ ...prev, isLoading: true, error: null }));
+
+    try {
+      const result = await apiClient.signup(name, email, password);
+      const user: User = {
+        id: result.user.id,
+        email: result.user.email,
+        name: result.user.name ?? undefined,
+        githubUsername: result.user.githubUsername ?? undefined,
+      };
+      storedUser = user;
+
+      setState({
+        user,
+        isAuthenticated: true,
+        isLoading: false,
+        error: null,
+      });
+
+      return result;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Registration failed';
       setState({
         user: null,
         isAuthenticated: false,
@@ -91,6 +123,7 @@ export function useAuth() {
   return {
     ...state,
     login,
+    signup,
     logout,
   };
 }

--- a/products/pulse/apps/web/src/lib/api-client.ts
+++ b/products/pulse/apps/web/src/lib/api-client.ts
@@ -33,12 +33,19 @@ export class ApiClientError extends Error {
   }
 }
 
-interface LoginResponse {
+interface AuthUser {
   id: string;
   email: string;
-  name?: string;
-  role: string;
+  name: string | null;
+  githubUsername: string | null;
+  avatarUrl: string | null;
+  githubConnected: boolean;
+  createdAt: string;
+}
+
+interface LoginResponse {
   token: string;
+  user: AuthUser;
 }
 
 async function request<T>(

--- a/products/pulse/apps/web/tests/login-page.test.tsx
+++ b/products/pulse/apps/web/tests/login-page.test.tsx
@@ -8,6 +8,25 @@ jest.mock('next/link', () => {
   };
 });
 
+// Mock next/navigation
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+  usePathname: () => '/login',
+}));
+
+// Mock useAuth hook
+jest.mock('../src/hooks/useAuth', () => ({
+  useAuth: () => ({
+    login: jest.fn(),
+    signup: jest.fn(),
+    logout: jest.fn(),
+    isLoading: false,
+    isAuthenticated: false,
+    user: null,
+    error: null,
+  }),
+}));
+
 describe('Login Page', () => {
   it('renders the login form with email and password fields', () => {
     render(<LoginPage />);


### PR DESCRIPTION
## Summary
- Wire login and signup forms to the backend API with proper response shape mapping
- Add auth guard on all dashboard routes (redirects unauthenticated users to /login)
- Wire sidebar logout button with redirect back to /login

## Changes
- **`api-client.ts`** — Fix `LoginResponse` interface to match backend's `{ token, user: {...} }` nested shape
- **`useAuth.ts`** — Fix response mapping, add `signup()` method, remove unused `role` field
- **`login/page.tsx`** — Replace TODO stub with `useAuth().login()` + router redirect to `/dashboard`
- **`signup/page.tsx`** — Replace TODO stub with `useAuth().signup()` + router redirect to `/dashboard`
- **`dashboard/layout.tsx`** — Add auth guard via `TokenManager.hasToken()` check + logout handler
- **`Sidebar.tsx`** — Add `onLogout` prop, wire logout button
- **`login-page.test.tsx`** — Add mocks for `next/navigation` and `useAuth`

## Test plan
- [ ] Sign up with new account at `/signup` — verify redirect to dashboard
- [ ] Log out via sidebar — verify redirect to `/login`
- [ ] Log in with same credentials at `/login` — verify redirect to dashboard
- [ ] Visit `/dashboard` without auth — verify redirect to `/login`
- [ ] Verify 178/183 web tests pass (5 pre-existing failures unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)