### PR TITLE
feat(pulse): implement GitHub OAuth flow

### DIFF
--- a/products/pulse/apps/web/src/app/auth/callback/page.tsx
+++ b/products/pulse/apps/web/src/app/auth/callback/page.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { TokenManager } from '../../../lib/token-manager';
+
+export default function AuthCallbackPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const token = searchParams.get('token');
+    if (token) {
+      TokenManager.setToken(token);
+      router.replace('/dashboard');
+    } else {
+      router.replace('/login?error=auth_failed');
+    }
+  }, [router, searchParams]);
+
+  return (
+    <div className="min-h-screen bg-[var(--bg-page)] flex items-center justify-center">
+      <div className="text-center">
+        <div className="w-8 h-8 border-4 border-indigo-600 border-t-transparent rounded-full animate-spin mx-auto mb-4" />
+        <p className="text-[var(--text-secondary)]">Signing you in...</p>
+      </div>
+    </div>
+  );
+}

--- a/products/pulse/apps/web/src/app/login/page.tsx
+++ b/products/pulse/apps/web/src/app/login/page.tsx
@@ -1,14 +1,30 @@
 'use client';
 
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useState } from 'react';
 import { useAuth } from '../../hooks/useAuth';
 
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5003';
+
+const OAUTH_ERROR_MESSAGES: Record<string, string> = {
+  missing_code: 'GitHub authorization was cancelled.',
+  oauth_not_configured: 'GitHub OAuth is not configured on the server.',
+  token_exchange_failed: 'Failed to authenticate with GitHub. Please try again.',
+  github_profile_failed: 'Could not retrieve your GitHub profile.',
+  no_github_email: 'No verified email found on your GitHub account.',
+  oauth_failed: 'GitHub sign-in failed. Please try again.',
+  auth_failed: 'Authentication failed. Please try again.',
+};
+
 export default function LoginPage() {
+  const searchParams = useSearchParams();
+  const oauthError = searchParams.get('error');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(
+    oauthError ? OAUTH_ERROR_MESSAGES[oauthError] || 'Sign-in failed.' : null
+  );
   const router = useRouter();
   const { login, isLoading } = useAuth();
 
@@ -24,8 +40,7 @@ export default function LoginPage() {
   };
 
   const handleGitHubLogin = () => {
-    // TODO: redirect to GitHub OAuth
-    window.location.href = 'http://localhost:5003/api/v1/auth/github';
+    window.location.href = `${API_BASE_URL}/api/v1/auth/github`;
   };
 
   return (

--- a/products/pulse/apps/web/src/app/signup/page.tsx
+++ b/products/pulse/apps/web/src/app/signup/page.tsx
@@ -5,6 +5,8 @@ import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { useAuth } from '../../hooks/useAuth';
 
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5003';
+
 export default function SignupPage() {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
@@ -25,7 +27,7 @@ export default function SignupPage() {
   };
 
   const handleGitHubSignup = () => {
-    window.location.href = 'http://localhost:5003/api/v1/auth/github';
+    window.location.href = `${API_BASE_URL}/api/v1/auth/github`;
   };
 
   return (

--- a/products/pulse/apps/web/tests/login-page.test.tsx
+++ b/products/pulse/apps/web/tests/login-page.test.tsx
@@ -12,6 +12,7 @@ jest.mock('next/link', () => {
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
   usePathname: () => '/login',
+  useSearchParams: () => new URLSearchParams(),
 }));
 
 // Mock useAuth hook


### PR DESCRIPTION
## Summary
- Implement the full GitHub OAuth flow: initiate -> GitHub authorize -> callback -> token exchange -> user upsert -> frontend redirect
- Add frontend `/auth/callback` page that captures the JWT and redirects to dashboard
- Display OAuth error messages on the login page

## Changes

**Backend** (`apps/api/src/modules/auth/routes.ts`):
- Fix `redirect_uri` to point to backend `/api/v1/auth/github/callback` (was incorrectly pointing to frontend)
- Implement callback: exchange code for GitHub access token via `POST github.com/login/oauth/access_token`
- Fetch GitHub user profile (`/user`) and verified email (`/user/emails`)
- Upsert user by `githubUsername` or `email` — creates new account or links existing
- Encrypt GitHub access token with AES-256-GCM before DB storage
- Generate JWT and redirect to `FRONTEND_URL/auth/callback?token=...`
- All error paths redirect to `/login?error=<code>` with descriptive messages

**Frontend**:
- New `/auth/callback` page — stores token via `TokenManager`, redirects to dashboard
- Login page shows user-friendly OAuth error messages from query params
- GitHub button URLs now use `NEXT_PUBLIC_API_URL` env var (not hardcoded)

## Setup required to test
1. Create a GitHub OAuth App at https://github.com/settings/developers
2. Set callback URL to `http://localhost:5003/api/v1/auth/github/callback`
3. Update `.env`:
   ```
   GITHUB_CLIENT_ID=<your_client_id>
   GITHUB_CLIENT_SECRET=<your_client_secret>
   ```
4. Restart the API server

## Test plan
- [ ] Click "Continue with GitHub" on login page
- [ ] Authorize the OAuth app on GitHub
- [ ] Verify redirect back to Pulse dashboard (logged in)
- [ ] Verify user created in DB with encrypted GitHub token
- [ ] Click GitHub button without OAuth configured — verify error message on login page
- [ ] 178/183 web tests pass (5 pre-existing failures unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)