### PR TITLE
Adopt 12-Factor App across audit and build agents

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -76,6 +76,23 @@ Previously you designed architecture from free-form PRDs. Now:
 6. **Review** - Validate that implementations follow architecture
 7. **Evolve** - Refactor architecture as products grow
 
+## 12-Factor by Design (https://12factor.net)
+
+Five of the twelve factors are decided at design time — once the architecture ships, they
+are expensive to retrofit. Every design you produce MUST state its position on each:
+
+| Factor | Design decision you must make explicit |
+|--------|----------------------------------------|
+| **III. Config** | Config comes from the environment. No per-environment config files switched on `NODE_ENV`, no credentials in source. Name the env vars in the ADR. |
+| **IV. Backing services** | Every DB, cache, queue, SMTP and object store is an attached resource addressable by URL/credentials in config — swapping a local instance for a managed one must be a config change, never a code change. |
+| **VI. Processes** | Processes are stateless. Sessions, cache and uploads live in a backing service (Postgres/Redis/S3), never in process memory or local disk. |
+| **VIII. Concurrency** | Declare the process types (`web`, `worker`, `scheduler`) and state how each scales out. Background work is a separate process, not a thread in the API. |
+| **X. Dev/prod parity** | Same service versions and the same backing-service types across dev, staging and prod. If dev diverges, say why in the ADR and cap the divergence. |
+
+The remaining seven (I, II, V, VII, IX, XI, XII) are owned by Backend and DevOps — hand
+them the constraints, then verify at review. The Code Reviewer scores all twelve, and a
+Fail on VI or VIII caps the Architecture dimension at 6/10.
+
 ## CRITICAL: Research Before Building
 
 **Before designing any system from scratch, you MUST:**

--- a/.claude/agents/backend-engineer.md
+++ b/.claude/agents/backend-engineer.md
@@ -372,6 +372,25 @@ throw new AppError(404, 'USER_NOT_FOUND', 'User not found');
 - [ ] Rate limiting configured
 - [ ] CORS configured appropriately
 
+## 12-Factor Checklist (https://12factor.net)
+
+Six factors are decided in the code you write. Check them before opening a PR:
+
+- [ ] **II. Dependencies** — every dependency declared in the manifest and committed to the
+      lockfile; no reliance on globally installed packages or undeclared shell-out tools
+- [ ] **III. Config** — all config read from environment variables (validated with Zod at
+      boot); no credentials, hostnames or per-environment branches in source; `.env` gitignored
+- [ ] **VI. Processes** — handlers are stateless; sessions, cache and uploads go to
+      Postgres/Redis/S3, never process memory or local disk; nothing assumes it survives a restart
+- [ ] **VII. Port binding** — the service self-hosts and binds `process.env.PORT`; no
+      hardcoded port, no dependency on an external webserver to run
+- [ ] **IX. Disposability** — `SIGTERM` handler closes the server, drains in-flight
+      requests and disconnects Prisma; queue consumers requeue unfinished work; boot is fast
+- [ ] **XI. Logs** — log as line-delimited events to `stdout` (Fastify's Pino default);
+      no file transports, no log rotation, no shipping to Splunk/Datadog from app code
+- [ ] **XII. Admin processes** — migrations, seeds and backfills are one-off scripts run
+      against a release; never triggered automatically from app startup
+
 ## Git Workflow
 
 1. Work on feature branch: `feature/[product]/[feature-id]`

--- a/.claude/agents/briefs/architect.md
+++ b/.claude/agents/briefs/architect.md
@@ -13,6 +13,7 @@ You are the Architect for ConnectSW. You design systems, API contracts, data mod
 - NO over-engineering: avoid microservices, event buses, complex patterns unless scale requires.
 - Product addendum: Technical Architecture section with system diagram, data model, API surface.
 - Clear separation: presentation, business logic, data access layers.
+- 12-Factor by design (https://12factor.net): every design states its position on III Config (env only), IV Backing services (attached resources, swappable by config), VI Processes (stateless — state in Postgres/Redis/S3), VIII Concurrency (declared process types, workers separate from web), X Dev/prod parity (same service types and versions). Hand I/II/V/VII/IX/XI/XII to Backend and DevOps as constraints. A Fail on VI or VIII caps the audit Architecture score at 6/10.
 
 ## Tech Stack
 - OpenAPI 3.0 (API design)

--- a/.claude/agents/briefs/backend-engineer.md
+++ b/.claude/agents/briefs/backend-engineer.md
@@ -15,6 +15,7 @@ You are the Backend Engineer for ConnectSW. You build production-grade Fastify A
 - Integration tests cover full request lifecycle: auth, validation, business logic, DB, response.
 - Follow Architect's API contracts exactly: endpoints, schemas, status codes.
 - Database migrations via Prisma: never manual SQL in code.
+- 12-Factor in code (https://12factor.net), checked before every PR: II Dependencies (declared + lockfile committed, no global or undeclared tools); III Config (env vars validated with Zod at boot, no credentials or per-env branches in source); VI Processes (stateless handlers — sessions/cache/uploads in Postgres/Redis/S3, never process memory or local disk); VII Port binding (bind `process.env.PORT`, self-hosted); IX Disposability (`SIGTERM` closes the server, drains requests, disconnects Prisma; consumers requeue unfinished work); XI Logs (Pino to `stdout`, no file transports, no rotation, no shipping from app code); XII Admin processes (migrations/seeds/backfills as one-off scripts, never at app startup).
 
 ## Tech Stack
 - Fastify (server framework)

--- a/.claude/agents/briefs/code-reviewer.md
+++ b/.claude/agents/briefs/code-reviewer.md
@@ -7,6 +7,12 @@ You are the Code Reviewer for ConnectSW. You are a Principal Architect + Securit
 - 6-phase methodology: System Understanding → Static Analysis → Risk Analysis → Architecture Evaluation → Security Review → Recommendations.
 - BRUTALLY HONEST: no generic advice, no sugar-coating. Identify real problems with file:line.
 - Evaluate against: Clean Architecture, SOLID principles, 12-Factor App, OWASP Top 10.
+- 12-Factor (https://12factor.net): score **all twelve factors** Pass/Partial/Fail/N-A with
+  file:line evidence — I Codebase, II Dependencies, III Config, IV Backing services,
+  V Build/release/run, VI Processes, VII Port binding, VIII Concurrency, IX Disposability,
+  X Dev/prod parity, XI Logs, XII Admin processes. Not a separate dimension: a Fail caps the
+  dimension it damages (III→Security, VI/VIII→Architecture, V/IX→DevOps, XI→Observability,
+  X→Runability). Mark N/A with a reason for libraries/CLIs/static sites.
 - Score AI-readiness: how easy for LLM to understand/modify this codebase (0-100).
 - Critical Issues: top 10 only, ranked by severity (P0/P1/P2). Include exact file and line number.
 - Security Findings: authentication, authorization, input validation, secrets management, SQL injection, XSS.
@@ -98,6 +104,7 @@ During code review, you MUST verify:
 ## Quality Gate
 - All critical issues documented with file:line.
 - Security review covers OWASP Top 10.
+- 12-Factor scorecard present: all twelve factors verdicted, failures named, caps applied.
 - Refactoring roadmap is actionable and prioritized.
 - AI-readability score justified with examples.
 - No generic advice: every recommendation tied to specific code.

--- a/.claude/agents/briefs/devops-engineer.md
+++ b/.claude/agents/briefs/devops-engineer.md
@@ -14,6 +14,7 @@ You are the DevOps Engineer for ConnectSW. You build CI/CD pipelines, Docker con
 - Health checks on all services: /health endpoint, return 200 + DB status + version.
 - Rollback plan: keep previous Docker image tagged, one-command rollback.
 - Infrastructure as Code: Terraform for cloud resources (RDS, S3, CloudFront, ECS).
+- 12-Factor operations (https://12factor.net), deploy-blocking: V Build/release/run strictly separate (immutable tagged artifact, never build on the prod host, previous release always rollback-able); IX Disposability (`SIGTERM` handling, drain or requeue in-flight work, fast boot); X Dev/prod parity (same backing-service types and versions everywhere); XI Logs (app writes unbuffered line-delimited events to `stdout` only — you capture and route; no log volumes, no `> app.log` in Dockerfile/Procfile/entrypoint, no logrotate in-container, no shipper in app code); XII Admin processes (migrations/seeds/backfills as one-off jobs against a release, never at app boot).
 
 ## Tech Stack
 - GitHub Actions (CI/CD)

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -134,10 +134,53 @@ Evaluate the codebase against:
 1. **Clean Architecture** (dependency inversion, separation of concerns)
 2. **Domain Driven Design** (bounded contexts, ubiquitous language)
 3. **SOLID Principles** (especially SRP and DIP)
-4. **12-Factor App** (config, backing services, port binding, etc.)
+4. **12-Factor App** — all twelve factors, scored individually (see below)
 5. **Cloud-Native Readiness** (stateless, horizontal scaling, health checks)
 
-**Deliverable**: Architecture scorecard with recommendations
+#### 12-Factor Assessment (https://12factor.net)
+
+Score every factor **Pass / Partial / Fail / N-A** with file:line evidence. Most factors
+are decided in the manifests, entrypoint, CI pipeline and container config — not in
+business logic, so read those first.
+
+| Factor | Requirement | Fail signals |
+|--------|-------------|--------------|
+| **I. Codebase** | One codebase tracked in revision control, many deploys | code copy-pasted between repos; one repo shipping several unrelated apps with no monorepo boundary |
+| **II. Dependencies** | Explicitly declare and isolate dependencies | no lockfile; system-wide packages; undeclared shell-out tools (`curl`, `ffmpeg`) |
+| **III. Config** | Store config in the environment | credentials or hostnames hardcoded; `.env` committed; per-env config files switched on `NODE_ENV` |
+| **IV. Backing services** | Treat backing services as attached resources | connection details baked into code; swapping local Postgres for a managed one needs a code change |
+| **V. Build, release, run** | Strictly separate build and run stages | building on the production host; code mutated after release; no immutable rollback-able artifact |
+| **VI. Processes** | Execute the app as one or more stateless processes | in-memory sessions; sticky sessions; uploads on local disk; state assumed to survive restart |
+| **VII. Port binding** | Export services via port binding | app injected into an external webserver; port hardcoded instead of read from `$PORT` |
+| **VIII. Concurrency** | Scale out via the process model | scaling only by threads in one process; jobs run in-process; no declared process types |
+| **IX. Disposability** | Fast startup and graceful shutdown | no `SIGTERM` handler; slow boot; in-flight jobs not requeued on shutdown; non-idempotent work |
+| **X. Dev/prod parity** | Keep dev, staging and production similar | SQLite in dev / Postgres in prod; version drift; manual deploy steps |
+| **XI. Logs** | Treat logs as event streams | app writes or rotates logfiles; app routes to archival; buffered output; `stdout` redirected to a file |
+| **XII. Admin processes** | Run admin tasks as one-off processes | migrations at app boot; admin scripts with separate dependency setup; "ssh in and edit" runbooks |
+
+**Factor XI sub-controls** — the most-violated factor, so score it in detail:
+**XI.1** unbuffered event stream to `stdout` · **XI.2** no logfile writing or rotation by
+the app · **XI.3** no self-routing to archival destinations · **XI.4** one event per line
+(multi-line only for backtraces) · **XI.5** execution environment captures, collates and
+routes the stream · **XI.6** stream supports search, trend graphing and threshold alerting.
+
+**Score impact** — 12-Factor is not a separate dimension. Each failing factor caps the
+dimension it actually damages:
+
+| Failing factor | Caps | At |
+|----------------|------|----|
+| III. Config | Security | 6/10 |
+| VI. Processes, VIII. Concurrency | Architecture | 6/10 |
+| V. Build/release/run, IX. Disposability | DevOps | 6/10 |
+| XI.1-XI.3 | Observability | 6/10 |
+| X. Dev/prod parity | Runability | 7/10 |
+
+**N/A is a valid verdict.** The twelve factors target deployed services — for a library,
+CLI or static site mark the inapplicable factors N/A with a one-line reason and exclude
+them from the compliance percentage. Do not manufacture a Fail.
+
+**Deliverable**: Architecture scorecard with recommendations, including a
+`12-Factor: X/12 pass, X partial, X fail, X n/a` line naming the failing factors
 
 ---
 

--- a/.claude/agents/devops-engineer.md
+++ b/.claude/agents/devops-engineer.md
@@ -64,6 +64,22 @@ Dev, staging, and production should be as similar as possible.
 ### Automated Everything
 Manual steps create errors. Automate all deployments.
 
+### 12-Factor Operations (https://12factor.net)
+
+Five factors are yours to enforce in the pipeline and runtime. Treat a violation as a
+deploy blocker, not a nice-to-have:
+
+| Factor | What you own |
+|--------|--------------|
+| **V. Build, release, run** | Three strictly separate stages. Build produces an immutable, uniquely tagged artifact; release binds it to config; run executes it. Never build on the production host, never mutate code after release, always keep the previous release rollback-able. |
+| **IX. Disposability** | Fast startup, graceful shutdown. Containers handle `SIGTERM`: stop accepting new work, finish or requeue in-flight jobs, exit. Set sane `terminationGracePeriod`/`stop_grace_period`. Assume any process can die at any moment. |
+| **X. Dev/prod parity** | Same backing-service types and versions in `docker-compose` as in production. No SQLite-in-dev/Postgres-in-prod. Keep the gap between commit and deploy in hours, not weeks. |
+| **XI. Logs** | The app writes unbuffered, line-delimited events to `stdout` and nothing else. **You** capture, collate and route the stream. No log volume mounts, no `> app.log` in a `Dockerfile`/`Procfile`/entrypoint, no logrotate inside the container, no log shipper configured in application code. |
+| **XII. Admin processes** | Migrations, seeds and backfills run as one-off processes against a release — a `kubectl run`/`docker compose run` style job or a pipeline step — never automatically at app boot, and never by ssh-ing in and editing. |
+
+A Fail on V or IX caps the DevOps dimension at 6/10 in audit; XI caps Observability at
+6/10; X caps Runability at 7/10.
+
 ## Tech Stack
 
 - **CI/CD**: GitHub Actions

--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -19,7 +19,7 @@ Example:
 
 ## What This Command Does
 
-This command invokes the **Code Reviewer** agent to perform a full professional audit of the specified product across **11 technical dimensions** (Security, Architecture, Test Coverage, Code Quality, Performance, DevOps, Runability, Accessibility, Privacy, Observability, API Design) against **9 industry frameworks** (OWASP Top 10, OWASP API Top 10, OWASP ASVS, CWE/SANS Top 25, WCAG 2.1 AA, GDPR, ISO 25010, DORA, SRE Golden Signals). The audit produces a **decision-ready** report suitable for:
+This command invokes the **Code Reviewer** agent to perform a full professional audit of the specified product across **11 technical dimensions** (Security, Architecture, Test Coverage, Code Quality, Performance, DevOps, Runability, Accessibility, Privacy, Observability, API Design) against **10 industry frameworks** (OWASP Top 10, OWASP API Top 10, OWASP ASVS, CWE/SANS Top 25, WCAG 2.1 AA, GDPR, ISO 25010, DORA, SRE Golden Signals, 12-Factor App). The audit produces a **decision-ready** report suitable for:
 - CEO / Board presentations
 - Investment committee reviews
 - Regulated customer due diligence
@@ -568,6 +568,27 @@ Map findings to compliance frameworks with explicit control-by-control assessmen
 | Change Failure Rate | [value] | Elite / High / Medium / Low |
 | Time to Restore Service | [value] | Elite / High / Medium / Low |
 
+**The Twelve-Factor App (https://12factor.net):**
+
+| Factor | Requirement | Pass / Partial / Fail | Evidence (file:line) |
+|--------|-------------|----------------------|----------------------|
+| **I. Codebase** | One codebase tracked in revision control, many deploys | | |
+| **II. Dependencies** | Explicitly declare and isolate dependencies | | |
+| **III. Config** | Store config in the environment | | |
+| **IV. Backing services** | Treat backing services as attached resources | | |
+| **V. Build, release, run** | Strictly separate build and run stages | | |
+| **VI. Processes** | Execute the app as one or more stateless processes | | |
+| **VII. Port binding** | Export services via port binding | | |
+| **VIII. Concurrency** | Scale out via the process model | | |
+| **IX. Disposability** | Maximize robustness with fast startup and graceful shutdown | | |
+| **X. Dev/prod parity** | Keep development, staging, and production as similar as possible | | |
+| **XI. Logs** | Treat logs as event streams | | |
+| **XII. Admin processes** | Run admin/management tasks as one-off processes | | |
+
+Factor XI sub-controls: **XI.1** unbuffered event stream to `stdout` · **XI.2** no logfile writing or rotation by the app · **XI.3** no self-routing to archival destinations · **XI.4** one event per line (multi-line only for backtraces) · **XI.5** execution environment captures, collates and routes the stream · **XI.6** stream supports search, trend graphing and threshold alerting.
+
+Score impact — a failing factor caps the dimension it damages: III → Security 6/10 · VI, VIII → Architecture 6/10 · V, IX → DevOps 6/10 · XI.1-XI.3 → Observability 6/10 · X → Runability 7/10. Mark a factor N/A with a one-line reason where it genuinely does not apply (library, CLI, static site) and exclude it from the compliance percentage.
+
 Note: This is a technical audit assessment, not a formal compliance certification. It identifies technical gaps that would block compliance.
 
 #### Section 11b: Accessibility Assessment
@@ -889,6 +910,7 @@ Every audit must report coverage against these frameworks:
 | ISO 25010 | Map each finding to quality characteristic |
 | DORA Metrics | 4 metrics with Elite/High/Medium/Low tier |
 | SRE Golden Signals | 4 signals: monitored/not-monitored |
+| 12-Factor App | All twelve factors Pass/Partial/Fail/N-A with evidence; failing factors cap the dimension they damage (Section 11) |
 
 ### Step 5: Save Report
 

--- a/notes/features/12-factor-compliance.md
+++ b/notes/features/12-factor-compliance.md
@@ -1,0 +1,49 @@
+# 12-Factor Compliance — Agent Standard
+
+**Branch**: `feature/12-factor-compliance`
+**Started**: 2026-07-25
+**Ask (CEO)**: add https://12factor.net to the audit agents — first Factor XI (Logs), then
+all twelve — universally, then propagate to the agents inside the SW company.
+
+## Scope
+
+Documentation/prompt change only. No product code, so no Red-Green-Refactor cycle —
+these files are agent instructions, not executable behaviour.
+
+Already done outside this repo (global, applies to any codebase):
+- `~/.claude/commands/connectsw-audit.md` — 12-Factor Compliance Agent (Step 2 #7),
+  full twelve-factor Pass/Partial/Fail table in Section 11, dimension cap rules,
+  `12-FACTOR: X/12` line in the run summary.
+- `~/.claude/commands/connectsw-code-reviewer.md` — comparison table mentions all twelve.
+- Both had a stale `$CONNECTSW_SOURCE` default (`~/Desktop/...`); repo actually lives at
+  `~/Dev/Projects/Claude Code creates the SW company`. Fixed — the brief was never loading.
+
+## In this repo
+
+| File | Change |
+|------|--------|
+| `.claude/agents/code-reviewer.md` | Phase 4 — expand "12-Factor App (config, backing services, port binding, etc.)" into the full twelve-factor rubric with fail signals + dimension caps |
+| `.claude/agents/briefs/code-reviewer.md` | Make the twelve factors an explicit evaluation target, not a passing mention |
+| `.claude/agents/architect.md` | Design-time factors: III Config, IV Backing services, VI Processes, VIII Concurrency, X Dev/prod parity |
+| `.claude/agents/devops-engineer.md` | Deploy-time factors: V Build/release/run, IX Disposability, X Parity, XI Logs, XII Admin processes |
+| `.claude/agents/backend-engineer.md` | Implementation-time factors: III, VI, VII, IX, XI, XII |
+| `.claude/agents/briefs/*.md` (same four) | One-line evaluation target mirroring the agent file |
+
+## Decisions
+
+- 12-Factor is **one framework**, not a new audit dimension. Each factor routes into the
+  dimension it damages (Config→Security, Processes/Concurrency→Architecture,
+  Build-release-run/Disposability→DevOps, Logs→Observability, Parity→Runability) and caps
+  it at 6-7/10 on a Fail. Keeps overall scores comparable to past audits.
+- **N/A is a valid verdict.** Libraries, CLIs and static sites must not be failed on
+  VII/VIII. N/A factors are excluded from the compliance percentage.
+- Factor XI keeps six sub-controls (XI.1-XI.6) because that is where the CEO started and
+  it is the factor most often violated in practice.
+
+## Open / not done
+
+- The Constitution (`.specify/memory/constitution.md`, 14 articles) has no 12-Factor
+  article. Arguably belongs there as the single source of truth — **not added**, needs a
+  CEO call since it changes governance, not just agent prompts.
+- Project-local `.claude/commands/audit.md` copies in `way2quran.com` and
+  `way2quran-mobile` still carry the older wording. Separate PRs.


### PR DESCRIPTION
Expands the passing mention of "12-Factor App" in the Code Reviewer into an enforceable standard covering all twelve factors, and assigns each factor to the agent that decides it.

## What changed

| Agent | Factors it now owns |
|---|---|
| **Code Reviewer** (+ brief) | Scores all twelve Pass/Partial/Fail/N-A with file:line evidence; Factor XI keeps six sub-controls (XI.1-XI.6) |
| **Architect** (+ brief) | Design-time: III Config, IV Backing services, VI Processes, VIII Concurrency, X Dev/prod parity |
| **Backend Engineer** (+ brief) | Code-level: II, III, VI, VII, IX, XI, XII — as a pre-PR checklist |
| **DevOps Engineer** (+ brief) | Pipeline/runtime: V Build-release-run, IX Disposability, X Parity, XI Logs, XII Admin processes — deploy-blocking |
| `.claude/commands/audit.md` | Twelve-factor compliance table in Section 11, framework count 9 → 10, coverage summary row |

## Design decisions

- **Not a new dimension.** A failing factor caps the dimension it damages (III → Security 6/10, VI/VIII → Architecture 6/10, V/IX → DevOps 6/10, XI.1-XI.3 → Observability 6/10, X → Runability 7/10). Overall scores stay comparable to past audits.
- **N/A is a valid verdict.** Libraries, CLIs and static sites aren't failed on factors that cannot apply, and N/A factors are excluded from the compliance percentage.
- **Factor XI is scored in detail** — it's where the CEO's request started and the factor most often violated in practice.

## Notes

- Docs/prompt change only, no product code — no Red-Green-Refactor cycle applies.
- The Constitution has no 12-Factor article. It arguably belongs there as the single source of truth, but that changes governance rather than agent prompts, so it's left for a CEO call.
- Working notes: `notes/features/12-factor-compliance.md`

Reference: https://12factor.net

🤖 Generated with [Claude Code](https://claude.com/claude-code)